### PR TITLE
Implement agent registry first slice

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install test dependency
+        run: python3 -m pip install pytest
+      - name: Validate examples
+        run: make validate
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: validate test
+
+validate:
+	python3 tools/validate_agent_registry_examples.py
+
+test:
+	python3 -m pytest -q tools/tests

--- a/docs/AGENT_REGISTRY.md
+++ b/docs/AGENT_REGISTRY.md
@@ -1,0 +1,32 @@
+# Agent Registry
+
+Agent Registry records governed agent identity, session authority, tool grants, revocation state, and evidence references for SocioProphet model fabric.
+
+It is not an identity provider and does not grant live runtime authority in this first slice. It records deterministic, reference-only examples that Model Router, Guardrail Fabric, Model Governance Ledger, Prophet Platform, and Prophet CLI can consume.
+
+## Role in model fabric
+
+- `model-router` uses agent authority as a routing input.
+- `guardrail-fabric` uses authority context as policy input.
+- `model-governance-ledger` stores authority/session evidence refs.
+- `prophet-cli` delegates `prophet agent registry list` here once packaging lands.
+
+## First record kinds
+
+- `AgentSpec`
+- `ToolGrant`
+- `SessionAuthority`
+- `RevocationRecord`
+
+## Authority boundary
+
+This repository records authority claims and revocation records. It must not store secrets, credentials, tokens, raw private prompts, or live identity-provider state.
+
+Tool grants are constrained by reference-only policy and evidence requirements.
+
+## Validation
+
+```bash
+make validate
+make test
+```

--- a/examples/agent-spec.example.json
+++ b/examples/agent-spec.example.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "agentregistry.socioprophet.dev/v1",
+  "kind": "AgentSpec",
+  "metadata": {
+    "agentId": "agent://socioprophet/demo-analyst",
+    "agentKind": "codex",
+    "version": "0.1.0"
+  },
+  "spec": {
+    "ownerRef": "team://socioprophet/model-fabric",
+    "allowedSurfaceRefs": [
+      "surface://language/summarization",
+      "surface://model-routing/demo",
+      "surface://guardrail/default-safe-text"
+    ],
+    "toolGrantRefs": ["grant://agent/demo-analyst/model-route-read"],
+    "memoryPolicyRef": "policy://memory/session-scoped-no-training",
+    "sessionPolicyRef": "policy://session/evidence-required",
+    "evidenceRef": "evidence://agent-registry/demo/agent-spec-001",
+    "revocationRef": "revocation://agent/demo-analyst/current"
+  }
+}

--- a/examples/revocation-record.example.json
+++ b/examples/revocation-record.example.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "agentregistry.socioprophet.dev/v1",
+  "kind": "RevocationRecord",
+  "metadata": {
+    "revocationId": "revocation://agent/demo-analyst/current",
+    "createdAt": "2026-04-29T00:00:00Z"
+  },
+  "spec": {
+    "agentId": "agent://socioprophet/demo-analyst",
+    "revokedToolGrantRefs": [],
+    "revokedSurfaceRefs": [],
+    "status": "not-revoked",
+    "reasonCodes": ["active-authority"],
+    "evidenceRef": "evidence://agent-registry/demo/revocation-001"
+  }
+}

--- a/examples/session-authority.example.json
+++ b/examples/session-authority.example.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "agentregistry.socioprophet.dev/v1",
+  "kind": "SessionAuthority",
+  "metadata": {
+    "sessionId": "session://agent/demo-analyst/001",
+    "createdAt": "2026-04-29T00:00:00Z"
+  },
+  "spec": {
+    "agentId": "agent://socioprophet/demo-analyst",
+    "activeToolGrantRefs": ["grant://agent/demo-analyst/model-route-read"],
+    "activeSurfaceRefs": ["surface://model-routing/demo", "surface://guardrail/default-safe-text"],
+    "sessionPolicyRef": "policy://session/evidence-required",
+    "memoryPolicyRef": "policy://memory/session-scoped-no-training",
+    "evidenceRef": "evidence://agent-registry/demo/session-authority-001",
+    "status": "active"
+  }
+}

--- a/examples/tool-grant.example.json
+++ b/examples/tool-grant.example.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "agentregistry.socioprophet.dev/v1",
+  "kind": "ToolGrant",
+  "metadata": {
+    "grantId": "grant://agent/demo-analyst/model-route-read",
+    "version": "0.1.0"
+  },
+  "spec": {
+    "agentId": "agent://socioprophet/demo-analyst",
+    "toolRef": "tool://model-router/emit-demo-decision",
+    "scope": "read-evaluate-only",
+    "constraints": [
+      "no-live-provider-call",
+      "no-secret-access",
+      "no-model-artifact-write",
+      "evidence-required"
+    ],
+    "expiresAt": "2026-12-31T23:59:59Z",
+    "evidenceRef": "evidence://agent-registry/demo/tool-grant-001"
+  }
+}

--- a/tools/tests/test_agent_registry_examples.py
+++ b/tools/tests/test_agent_registry_examples.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_agent_registry_examples_validate() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_agent_registry_examples.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: validated" in result.stdout
+
+
+def test_agent_spec_references_tool_grant_and_revocation() -> None:
+    agent = json.loads((ROOT / "examples" / "agent-spec.example.json").read_text(encoding="utf-8"))
+    spec = agent["spec"]
+    assert spec["toolGrantRefs"] == ["grant://agent/demo-analyst/model-route-read"]
+    assert spec["revocationRef"] == "revocation://agent/demo-analyst/current"
+    assert "surface://model-routing/demo" in spec["allowedSurfaceRefs"]
+
+
+def test_tool_grant_is_constrained_and_reference_only() -> None:
+    grant = json.loads((ROOT / "examples" / "tool-grant.example.json").read_text(encoding="utf-8"))
+    constraints = set(grant["spec"]["constraints"])
+    assert "no-live-provider-call" in constraints
+    assert "no-secret-access" in constraints
+    assert "evidence-required" in constraints
+
+
+def test_session_authority_can_be_revoked_by_record() -> None:
+    session = json.loads((ROOT / "examples" / "session-authority.example.json").read_text(encoding="utf-8"))
+    revocation = json.loads((ROOT / "examples" / "revocation-record.example.json").read_text(encoding="utf-8"))
+    assert session["spec"]["agentId"] == revocation["spec"]["agentId"]
+    assert revocation["spec"]["status"] == "not-revoked"

--- a/tools/validate_agent_registry_examples.py
+++ b/tools/validate_agent_registry_examples.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = [
+    "agent-spec.example.json",
+    "tool-grant.example.json",
+    "session-authority.example.json",
+    "revocation-record.example.json",
+]
+REQUIRED_AGENT_SPEC = {"ownerRef", "allowedSurfaceRefs", "toolGrantRefs", "memoryPolicyRef", "sessionPolicyRef", "evidenceRef", "revocationRef"}
+REQUIRED_TOOL_GRANT = {"agentId", "toolRef", "scope", "constraints", "expiresAt", "evidenceRef"}
+REQUIRED_SESSION = {"agentId", "activeToolGrantRefs", "activeSurfaceRefs", "sessionPolicyRef", "memoryPolicyRef", "evidenceRef", "status"}
+REQUIRED_REVOCATION = {"agentId", "revokedToolGrantRefs", "revokedSurfaceRefs", "status", "reasonCodes", "evidenceRef"}
+ALLOWED_AGENT_KINDS = {"codex", "copilot", "human", "local-cli", "system"}
+
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def fail(msg: str) -> int:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    return 1
+
+
+def require_fields(path: Path, spec: dict, required: set[str]) -> int:
+    missing = sorted(required - set(spec))
+    if missing:
+        return fail(f"{path.name}: missing spec fields {missing}")
+    return 0
+
+
+def validate_record(path: Path) -> int:
+    doc = load(path)
+    if doc.get("apiVersion") != "agentregistry.socioprophet.dev/v1":
+        return fail(f"{path.name}: apiVersion invalid")
+    kind = doc.get("kind")
+    metadata = doc.get("metadata", {})
+    spec = doc.get("spec", {})
+    if kind == "AgentSpec":
+        if not metadata.get("agentId") or metadata.get("agentKind") not in ALLOWED_AGENT_KINDS:
+            return fail(f"{path.name}: metadata.agentId and valid agentKind required")
+        rc = require_fields(path, spec, REQUIRED_AGENT_SPEC)
+        if rc:
+            return rc
+        if not spec["allowedSurfaceRefs"] or not spec["toolGrantRefs"]:
+            return fail(f"{path.name}: allowedSurfaceRefs and toolGrantRefs must be non-empty")
+    elif kind == "ToolGrant":
+        if not metadata.get("grantId"):
+            return fail(f"{path.name}: grantId required")
+        rc = require_fields(path, spec, REQUIRED_TOOL_GRANT)
+        if rc:
+            return rc
+        if not spec["constraints"]:
+            return fail(f"{path.name}: constraints must be non-empty")
+    elif kind == "SessionAuthority":
+        if not metadata.get("sessionId"):
+            return fail(f"{path.name}: sessionId required")
+        rc = require_fields(path, spec, REQUIRED_SESSION)
+        if rc:
+            return rc
+        if spec["status"] not in {"active", "expired", "revoked"}:
+            return fail(f"{path.name}: session status invalid")
+    elif kind == "RevocationRecord":
+        if not metadata.get("revocationId"):
+            return fail(f"{path.name}: revocationId required")
+        rc = require_fields(path, spec, REQUIRED_REVOCATION)
+        if rc:
+            return rc
+        if spec["status"] not in {"not-revoked", "revoked"}:
+            return fail(f"{path.name}: revocation status invalid")
+    else:
+        return fail(f"{path.name}: unknown kind {kind}")
+    return 0
+
+
+def main() -> int:
+    for name in EXAMPLES:
+        rc = validate_record(ROOT / "examples" / name)
+        if rc:
+            return rc
+    print(f"OK: validated {len(EXAMPLES)} agent registry examples")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the first Agent Registry slice for SocioProphet model fabric.

Adds:

- agent spec, tool grant, session authority, and revocation example records
- deterministic agent registry example validator
- pytest coverage
- Makefile targets: `validate`, `test`
- GitHub Actions validation workflow
- Agent Registry integration docs

## Model fabric role

`agent-registry` owns references for agent identity, tool grants, session authority, and revocation state.

Integration boundaries:

- `model-router` uses agent authority as a routing input
- `guardrail-fabric` uses authority context as policy input
- `model-governance-ledger` records authority/session evidence refs
- `prophet-cli` delegates `prophet agent registry list` here when packaging lands

## Validation

```bash
make validate
make test
```

Closes #2
