### PR TITLE
Add Professional Intelligence agent specs and tool grants

### DIFF
--- a/docs/PROFESSIONAL_INTELLIGENCE_AGENTS.md
+++ b/docs/PROFESSIONAL_INTELLIGENCE_AGENTS.md
@@ -1,0 +1,68 @@
+# Professional Intelligence Agents
+
+## Purpose
+
+This document defines the first Agent Registry authority surface for the Professional Intelligence OS Gate 3 demo path.
+
+Agent Registry does not execute agents. It records governed agent identity, scoped tool grants, session authority, revocation state, and evidence references that Agentplane, Policy Fabric, Model Router, Guardrail Fabric, Memory Mesh, Prophet Workspace, and Prophet Platform can consume.
+
+## Registered agents
+
+The seed Professional Intelligence agent set is defined in:
+
+- `examples/professional-intelligence/agent-specs.example.json`
+
+Initial agents:
+
+- `opportunity-review-agent`
+- `relationship-agent`
+- `policy-review-agent`
+- `workspace-setup-agent`
+
+## Tool grants
+
+Tool grants are defined in:
+
+- `examples/professional-intelligence/tool-grants.example.json`
+
+The grants are intentionally scoped and evidence-bound:
+
+- read/evaluate search context;
+- draft-only workroom update;
+- read-only context access;
+- evaluate-only policy checks;
+- draft-only workroom creation.
+
+No grant stores secrets, tokens, raw prompts, or live identity-provider state.
+
+## Session and revocation
+
+Session authority and revocation records are defined in:
+
+- `examples/professional-intelligence/session-authority.example.json`
+- `examples/professional-intelligence/revocation-record.example.json`
+
+A session must reference registered agents and active grants. A revocation record must identify the agent and current revocation state.
+
+## Validation
+
+Professional Intelligence examples are included in the existing repo validation path:
+
+```bash
+make validate
+make test
+```
+
+The validator also checks cross references:
+
+- every agent grant reference exists;
+- every grant references a registered agent;
+- session authority references registered agents and grants;
+- revocation records reference registered agents;
+- every tool grant includes `evidence-required`.
+
+## Gate 3 role
+
+This work supports Gate 3 of the Professional Intelligence OS control register: create a runnable demo slice.
+
+It supplies the authority and tool-grant layer for the Agentplane workflow bundle, the Prophet Workspace workroom fixture, Policy Fabric policy decisions, ContractForge obligations, and future Memory Mesh context packs.

--- a/examples/professional-intelligence/agent-specs.example.json
+++ b/examples/professional-intelligence/agent-specs.example.json
@@ -1,0 +1,97 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentSpec",
+    "metadata": {
+      "agentId": "agent://professional-intelligence/opportunity-review-agent",
+      "agentKind": "codex",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "ownerRef": "team://socioprophet/professional-intelligence",
+      "allowedSurfaceRefs": [
+        "surface://professional-intelligence/client-opportunity-review",
+        "surface://workspace/professional-workroom",
+        "surface://policy/professional-policy-decision"
+      ],
+      "toolGrantRefs": [
+        "grant://professional-intelligence/opportunity-review-agent/search-read",
+        "grant://professional-intelligence/opportunity-review-agent/workroom-update"
+      ],
+      "memoryPolicyRef": "policy://memory/workroom-scoped",
+      "sessionPolicyRef": "policy://session/evidence-required",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/opportunity-review-agent",
+      "revocationRef": "revocation://professional-intelligence/current"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentSpec",
+    "metadata": {
+      "agentId": "agent://professional-intelligence/relationship-agent",
+      "agentKind": "copilot",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "ownerRef": "team://socioprophet/professional-intelligence",
+      "allowedSurfaceRefs": [
+        "surface://institution-graph/relationship-map",
+        "surface://memory/context-pack",
+        "surface://workspace/professional-workroom"
+      ],
+      "toolGrantRefs": [
+        "grant://professional-intelligence/relationship-agent/context-read"
+      ],
+      "memoryPolicyRef": "policy://memory/read-only-workroom-scoped",
+      "sessionPolicyRef": "policy://session/evidence-required",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/relationship-agent",
+      "revocationRef": "revocation://professional-intelligence/current"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentSpec",
+    "metadata": {
+      "agentId": "agent://professional-intelligence/policy-review-agent",
+      "agentKind": "codex",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "ownerRef": "team://socioprophet/professional-intelligence",
+      "allowedSurfaceRefs": [
+        "surface://policy/professional-policy-decision",
+        "surface://contractforge/obligation-ledger"
+      ],
+      "toolGrantRefs": [
+        "grant://professional-intelligence/policy-review-agent/policy-evaluate"
+      ],
+      "memoryPolicyRef": "policy://memory/no-write",
+      "sessionPolicyRef": "policy://session/evidence-required",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/policy-review-agent",
+      "revocationRef": "revocation://professional-intelligence/current"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentSpec",
+    "metadata": {
+      "agentId": "agent://professional-intelligence/workspace-setup-agent",
+      "agentKind": "system",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "ownerRef": "team://socioprophet/professional-intelligence",
+      "allowedSurfaceRefs": [
+        "surface://workspace/professional-workroom",
+        "surface://agentplane/workflow-bundle"
+      ],
+      "toolGrantRefs": [
+        "grant://professional-intelligence/workspace-setup-agent/workroom-create"
+      ],
+      "memoryPolicyRef": "policy://memory/no-write",
+      "sessionPolicyRef": "policy://session/evidence-required",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/workspace-setup-agent",
+      "revocationRef": "revocation://professional-intelligence/current"
+    }
+  }
+]

--- a/examples/professional-intelligence/revocation-record.example.json
+++ b/examples/professional-intelligence/revocation-record.example.json
@@ -1,0 +1,16 @@
+{
+  "apiVersion": "agentregistry.socioprophet.dev/v1",
+  "kind": "RevocationRecord",
+  "metadata": {
+    "revocationId": "revocation://professional-intelligence/current",
+    "createdAt": "2026-04-29T16:35:00Z"
+  },
+  "spec": {
+    "agentId": "agent://professional-intelligence/opportunity-review-agent",
+    "revokedToolGrantRefs": [],
+    "revokedSurfaceRefs": [],
+    "status": "not-revoked",
+    "reasonCodes": ["active-professional-intelligence-demo-authority"],
+    "evidenceRef": "evidence://agent-registry/professional-intelligence/revocation-current"
+  }
+}

--- a/examples/professional-intelligence/session-authority.example.json
+++ b/examples/professional-intelligence/session-authority.example.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "agentregistry.socioprophet.dev/v1",
+  "kind": "SessionAuthority",
+  "metadata": {
+    "sessionId": "session://professional-intelligence/demo-001",
+    "createdAt": "2026-04-29T16:35:00Z"
+  },
+  "spec": {
+    "agentId": "agent://professional-intelligence/opportunity-review-agent",
+    "activeToolGrantRefs": [
+      "grant://professional-intelligence/opportunity-review-agent/search-read",
+      "grant://professional-intelligence/opportunity-review-agent/workroom-update"
+    ],
+    "activeSurfaceRefs": [
+      "surface://professional-intelligence/client-opportunity-review",
+      "surface://workspace/professional-workroom"
+    ],
+    "sessionPolicyRef": "policy://session/evidence-required",
+    "memoryPolicyRef": "policy://memory/workroom-scoped",
+    "evidenceRef": "evidence://agent-registry/professional-intelligence/session-demo-001",
+    "status": "active"
+  }
+}

--- a/examples/professional-intelligence/tool-grants.example.json
+++ b/examples/professional-intelligence/tool-grants.example.json
@@ -1,0 +1,82 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "ToolGrant",
+    "metadata": {
+      "grantId": "grant://professional-intelligence/opportunity-review-agent/search-read",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "agentId": "agent://professional-intelligence/opportunity-review-agent",
+      "toolRef": "tool://sherlock-search/search-packet-read",
+      "scope": "read-evaluate-only",
+      "constraints": ["workroom-scoped", "source-citation-required", "evidence-required", "no-secret-access"],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/grant-search-read"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "ToolGrant",
+    "metadata": {
+      "grantId": "grant://professional-intelligence/opportunity-review-agent/workroom-update",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "agentId": "agent://professional-intelligence/opportunity-review-agent",
+      "toolRef": "tool://prophet-workspace/professional-workroom-update",
+      "scope": "draft-update-only",
+      "constraints": ["policy-decision-required", "evidence-required", "human-review-required"],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/grant-workroom-update"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "ToolGrant",
+    "metadata": {
+      "grantId": "grant://professional-intelligence/relationship-agent/context-read",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "agentId": "agent://professional-intelligence/relationship-agent",
+      "toolRef": "tool://memory-mesh/context-pack-read",
+      "scope": "read-only",
+      "constraints": ["workroom-scoped", "no-memory-write", "evidence-required"],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/grant-context-read"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "ToolGrant",
+    "metadata": {
+      "grantId": "grant://professional-intelligence/policy-review-agent/policy-evaluate",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "agentId": "agent://professional-intelligence/policy-review-agent",
+      "toolRef": "tool://policy-fabric/professional-policy-decision-evaluate",
+      "scope": "evaluate-only",
+      "constraints": ["no-policy-write", "evidence-required", "obligation-reference-required"],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/grant-policy-evaluate"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "ToolGrant",
+    "metadata": {
+      "grantId": "grant://professional-intelligence/workspace-setup-agent/workroom-create",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "agentId": "agent://professional-intelligence/workspace-setup-agent",
+      "toolRef": "tool://prophet-workspace/professional-workroom-create",
+      "scope": "create-draft-only",
+      "constraints": ["policy-decision-required", "evidence-required", "no-external-release"],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/professional-intelligence/grant-workroom-create"
+    }
+  }
+]

--- a/tools/tests/test_agent_registry_examples.py
+++ b/tools/tests/test_agent_registry_examples.py
@@ -8,6 +8,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def test_agent_registry_examples_validate() -> None:
     result = subprocess.run(
         [sys.executable, str(ROOT / "tools" / "validate_agent_registry_examples.py")],
@@ -21,7 +25,7 @@ def test_agent_registry_examples_validate() -> None:
 
 
 def test_agent_spec_references_tool_grant_and_revocation() -> None:
-    agent = json.loads((ROOT / "examples" / "agent-spec.example.json").read_text(encoding="utf-8"))
+    agent = load_json(ROOT / "examples" / "agent-spec.example.json")
     spec = agent["spec"]
     assert spec["toolGrantRefs"] == ["grant://agent/demo-analyst/model-route-read"]
     assert spec["revocationRef"] == "revocation://agent/demo-analyst/current"
@@ -29,7 +33,7 @@ def test_agent_spec_references_tool_grant_and_revocation() -> None:
 
 
 def test_tool_grant_is_constrained_and_reference_only() -> None:
-    grant = json.loads((ROOT / "examples" / "tool-grant.example.json").read_text(encoding="utf-8"))
+    grant = load_json(ROOT / "examples" / "tool-grant.example.json")
     constraints = set(grant["spec"]["constraints"])
     assert "no-live-provider-call" in constraints
     assert "no-secret-access" in constraints
@@ -37,7 +41,51 @@ def test_tool_grant_is_constrained_and_reference_only() -> None:
 
 
 def test_session_authority_can_be_revoked_by_record() -> None:
-    session = json.loads((ROOT / "examples" / "session-authority.example.json").read_text(encoding="utf-8"))
-    revocation = json.loads((ROOT / "examples" / "revocation-record.example.json").read_text(encoding="utf-8"))
+    session = load_json(ROOT / "examples" / "session-authority.example.json")
+    revocation = load_json(ROOT / "examples" / "revocation-record.example.json")
     assert session["spec"]["agentId"] == revocation["spec"]["agentId"]
+    assert revocation["spec"]["status"] == "not-revoked"
+
+
+def test_professional_intelligence_agent_specs_are_registered() -> None:
+    agents = load_json(ROOT / "examples" / "professional-intelligence" / "agent-specs.example.json")
+    agent_ids = {agent["metadata"]["agentId"] for agent in agents}
+    assert agent_ids == {
+        "agent://professional-intelligence/opportunity-review-agent",
+        "agent://professional-intelligence/relationship-agent",
+        "agent://professional-intelligence/policy-review-agent",
+        "agent://professional-intelligence/workspace-setup-agent",
+    }
+
+
+def test_professional_intelligence_tool_grants_are_scoped_and_evidence_bound() -> None:
+    grants = load_json(ROOT / "examples" / "professional-intelligence" / "tool-grants.example.json")
+    assert len(grants) == 5
+    for grant in grants:
+        constraints = set(grant["spec"]["constraints"])
+        assert "evidence-required" in constraints
+        assert grant["spec"]["scope"] in {"read-evaluate-only", "draft-update-only", "read-only", "evaluate-only", "create-draft-only"}
+
+
+def test_professional_intelligence_agent_grant_cross_refs() -> None:
+    agents = load_json(ROOT / "examples" / "professional-intelligence" / "agent-specs.example.json")
+    grants = load_json(ROOT / "examples" / "professional-intelligence" / "tool-grants.example.json")
+    grant_ids = {grant["metadata"]["grantId"] for grant in grants}
+    for agent in agents:
+        for grant_ref in agent["spec"]["toolGrantRefs"]:
+            assert grant_ref in grant_ids
+
+
+def test_professional_intelligence_session_and_revocation_reference_registered_agent() -> None:
+    agents = load_json(ROOT / "examples" / "professional-intelligence" / "agent-specs.example.json")
+    grants = load_json(ROOT / "examples" / "professional-intelligence" / "tool-grants.example.json")
+    session = load_json(ROOT / "examples" / "professional-intelligence" / "session-authority.example.json")
+    revocation = load_json(ROOT / "examples" / "professional-intelligence" / "revocation-record.example.json")
+
+    agent_ids = {agent["metadata"]["agentId"] for agent in agents}
+    grant_ids = {grant["metadata"]["grantId"] for grant in grants}
+
+    assert session["spec"]["agentId"] in agent_ids
+    assert revocation["spec"]["agentId"] in agent_ids
+    assert set(session["spec"]["activeToolGrantRefs"]).issubset(grant_ids)
     assert revocation["spec"]["status"] == "not-revoked"

--- a/tools/validate_agent_registry_examples.py
+++ b/tools/validate_agent_registry_examples.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES = [
-    "agent-spec.example.json",
-    "tool-grant.example.json",
-    "session-authority.example.json",
-    "revocation-record.example.json",
+    ROOT / "examples" / "agent-spec.example.json",
+    ROOT / "examples" / "tool-grant.example.json",
+    ROOT / "examples" / "session-authority.example.json",
+    ROOT / "examples" / "revocation-record.example.json",
+    ROOT / "examples" / "professional-intelligence" / "agent-specs.example.json",
+    ROOT / "examples" / "professional-intelligence" / "tool-grants.example.json",
+    ROOT / "examples" / "professional-intelligence" / "session-authority.example.json",
+    ROOT / "examples" / "professional-intelligence" / "revocation-record.example.json",
 ]
 REQUIRED_AGENT_SPEC = {"ownerRef", "allowedSurfaceRefs", "toolGrantRefs", "memoryPolicyRef", "sessionPolicyRef", "evidenceRef", "revocationRef"}
 REQUIRED_TOOL_GRANT = {"agentId", "toolRef", "scope", "constraints", "expiresAt", "evidenceRef"}
@@ -19,7 +24,7 @@ REQUIRED_REVOCATION = {"agentId", "revokedToolGrantRefs", "revokedSurfaceRefs", 
 ALLOWED_AGENT_KINDS = {"codex", "copilot", "human", "local-cli", "system"}
 
 
-def load(path: Path):
+def load(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
@@ -28,63 +33,121 @@ def fail(msg: str) -> int:
     return 1
 
 
-def require_fields(path: Path, spec: dict, required: set[str]) -> int:
+def require_fields(label: str, spec: dict, required: set[str]) -> int:
     missing = sorted(required - set(spec))
     if missing:
-        return fail(f"{path.name}: missing spec fields {missing}")
+        return fail(f"{label}: missing spec fields {missing}")
     return 0
 
 
-def validate_record(path: Path) -> int:
-    doc = load(path)
+def record_label(path: Path, index: int | None = None) -> str:
+    rel = path.relative_to(ROOT)
+    if index is None:
+        return str(rel)
+    return f"{rel}[{index}]"
+
+
+def validate_record(doc: dict[str, Any], label: str) -> int:
     if doc.get("apiVersion") != "agentregistry.socioprophet.dev/v1":
-        return fail(f"{path.name}: apiVersion invalid")
+        return fail(f"{label}: apiVersion invalid")
     kind = doc.get("kind")
     metadata = doc.get("metadata", {})
     spec = doc.get("spec", {})
     if kind == "AgentSpec":
         if not metadata.get("agentId") or metadata.get("agentKind") not in ALLOWED_AGENT_KINDS:
-            return fail(f"{path.name}: metadata.agentId and valid agentKind required")
-        rc = require_fields(path, spec, REQUIRED_AGENT_SPEC)
+            return fail(f"{label}: metadata.agentId and valid agentKind required")
+        rc = require_fields(label, spec, REQUIRED_AGENT_SPEC)
         if rc:
             return rc
         if not spec["allowedSurfaceRefs"] or not spec["toolGrantRefs"]:
-            return fail(f"{path.name}: allowedSurfaceRefs and toolGrantRefs must be non-empty")
+            return fail(f"{label}: allowedSurfaceRefs and toolGrantRefs must be non-empty")
     elif kind == "ToolGrant":
         if not metadata.get("grantId"):
-            return fail(f"{path.name}: grantId required")
-        rc = require_fields(path, spec, REQUIRED_TOOL_GRANT)
+            return fail(f"{label}: grantId required")
+        rc = require_fields(label, spec, REQUIRED_TOOL_GRANT)
         if rc:
             return rc
         if not spec["constraints"]:
-            return fail(f"{path.name}: constraints must be non-empty")
+            return fail(f"{label}: constraints must be non-empty")
+        if "evidence-required" not in set(spec["constraints"]):
+            return fail(f"{label}: evidence-required constraint is mandatory")
     elif kind == "SessionAuthority":
         if not metadata.get("sessionId"):
-            return fail(f"{path.name}: sessionId required")
-        rc = require_fields(path, spec, REQUIRED_SESSION)
+            return fail(f"{label}: sessionId required")
+        rc = require_fields(label, spec, REQUIRED_SESSION)
         if rc:
             return rc
         if spec["status"] not in {"active", "expired", "revoked"}:
-            return fail(f"{path.name}: session status invalid")
+            return fail(f"{label}: session status invalid")
     elif kind == "RevocationRecord":
         if not metadata.get("revocationId"):
-            return fail(f"{path.name}: revocationId required")
-        rc = require_fields(path, spec, REQUIRED_REVOCATION)
+            return fail(f"{label}: revocationId required")
+        rc = require_fields(label, spec, REQUIRED_REVOCATION)
         if rc:
             return rc
         if spec["status"] not in {"not-revoked", "revoked"}:
-            return fail(f"{path.name}: revocation status invalid")
+            return fail(f"{label}: revocation status invalid")
     else:
-        return fail(f"{path.name}: unknown kind {kind}")
+        return fail(f"{label}: unknown kind {kind}")
+    return 0
+
+
+def iter_records(path: Path):
+    doc = load(path)
+    if isinstance(doc, list):
+        for index, record in enumerate(doc):
+            yield record, record_label(path, index)
+    else:
+        yield doc, record_label(path)
+
+
+def validate_professional_intelligence_cross_refs() -> int:
+    base = ROOT / "examples" / "professional-intelligence"
+    agents = load(base / "agent-specs.example.json")
+    grants = load(base / "tool-grants.example.json")
+    session = load(base / "session-authority.example.json")
+    revocation = load(base / "revocation-record.example.json")
+
+    grant_ids = {grant["metadata"]["grantId"] for grant in grants}
+    agent_ids = {agent["metadata"]["agentId"] for agent in agents}
+
+    for agent in agents:
+        for grant_ref in agent["spec"]["toolGrantRefs"]:
+            if grant_ref not in grant_ids:
+                return fail(f"professional-intelligence: agent references missing grant {grant_ref}")
+
+    for grant in grants:
+        agent_id = grant["spec"]["agentId"]
+        if agent_id not in agent_ids:
+            return fail(f"professional-intelligence: grant references missing agent {agent_id}")
+
+    session_spec = session["spec"]
+    if session_spec["agentId"] not in agent_ids:
+        return fail("professional-intelligence: session references missing agent")
+    for grant_ref in session_spec["activeToolGrantRefs"]:
+        if grant_ref not in grant_ids:
+            return fail(f"professional-intelligence: session references missing grant {grant_ref}")
+
+    if revocation["spec"]["agentId"] not in agent_ids:
+        return fail("professional-intelligence: revocation references missing agent")
+
     return 0
 
 
 def main() -> int:
-    for name in EXAMPLES:
-        rc = validate_record(ROOT / "examples" / name)
-        if rc:
-            return rc
-    print(f"OK: validated {len(EXAMPLES)} agent registry examples")
+    count = 0
+    for path in EXAMPLES:
+        for record, label in iter_records(path):
+            rc = validate_record(record, label)
+            if rc:
+                return rc
+            count += 1
+
+    rc = validate_professional_intelligence_cross_refs()
+    if rc:
+        return rc
+
+    print(f"OK: validated {count} agent registry examples")
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds the Professional Intelligence OS agent authority surface to Agent Registry.

Adds:
- `examples/professional-intelligence/agent-specs.example.json`
- `examples/professional-intelligence/tool-grants.example.json`
- `examples/professional-intelligence/session-authority.example.json`
- `examples/professional-intelligence/revocation-record.example.json`
- `docs/PROFESSIONAL_INTELLIGENCE_AGENTS.md`

Updates:
- `tools/validate_agent_registry_examples.py` to validate list-based Professional Intelligence records and cross references.
- `tools/tests/test_agent_registry_examples.py` with Professional Intelligence coverage.

## Why

Gate 3 requires authority boundaries for the runnable Professional Intelligence demo slice. This gives Agent Registry scoped, evidence-bound agent identities and tool grants for opportunity review, relationship lookup, policy review, and workspace setup.

## Completion impact

- Governed execution substrate: ~35% -> ~42%
- Runtime implementation: ~12% -> ~15%
- Demo readiness: ~40% -> ~43%
- Overall alignment: ~45% -> ~47%

## Validation

```bash
make validate
make test
```

The validator checks:
- every agent grant reference exists;
- every grant references a registered agent;
- session authority references registered agents and grants;
- revocation records reference registered agents;
- every tool grant includes `evidence-required`.