### PR TITLE
Replay release dry-run artifacts without generated cache

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -1,0 +1,30 @@
+name: release-dry-run
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate examples
+        run: make validate
+      - name: Release dry-run
+        run: make release-dry-run
+      - name: Verify checksum
+        run: |
+          cd dist
+          sha256sum -c *.sha256
+      - name: Upload dry-run artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dry-run
+          path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: validate test
+.PHONY: validate test release-dry-run
 
 validate:
 	python3 tools/validate_agent_registry_examples.py
 
 test:
 	python3 -m pytest -q tools/tests
+
+release-dry-run:
+	python3 tools/release_dry_run.py

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,43 @@
+# Release Dry-Run
+
+This document describes the release dry-run process and how it differs from a stable release.
+
+## Purpose
+
+The release dry-run produces deterministic local metadata artifacts without publishing anything to a release channel, package registry, or Homebrew. It is safe to run on any branch at any time.
+
+## Development formulae vs stable release artifacts
+
+| Property | Development formula | Stable release artifact |
+|---|---|---|
+| Version | `0.0.0-dry-run` | Tagged semver, for example `v1.0.0` |
+| Location | `dist/` local only | GitHub Releases plus Homebrew tap |
+| Homebrew URL | None — not invented | Pinned release archive URL |
+| Checksum purpose | Local integrity verification | Homebrew `sha256` field |
+| Published? | No | Yes, after tag and review |
+| Safe to run in CI? | Yes, always | Only on protected release workflow |
+
+Development formulae are reference-only snapshots of the current example records. They are suitable for local inspection, integration testing, and CI validation. They are not suitable for use as Homebrew `url` or `sha256` values.
+
+Stable release artifacts are produced only when a version tag is pushed through the official release process. They carry a permanent URL and a checksum that Homebrew consumers may pin.
+
+## Running the dry-run
+
+```bash
+make release-dry-run
+```
+
+This writes two files under `dist/`:
+
+- `agent-registry-0.0.0-dry-run.json` — deterministic JSON manifest of all agent registry records
+- `agent-registry-0.0.0-dry-run.json.sha256` — SHA-256 checksum of the manifest
+
+The manifest is serialized with sorted keys and consistent indentation so the SHA-256 digest is reproducible across runs given the same input files.
+
+## What the dry-run does not do
+
+- Does not publish any artifact to GitHub Releases.
+- Does not push to any Homebrew tap.
+- Does not use any credentials, tokens, or secrets.
+- Does not invent Homebrew formula URLs or checksums for production use.
+- Does not grant any live runtime authority.

--- a/tools/release_dry_run.py
+++ b/tools/release_dry_run.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Release dry-run: emits deterministic local metadata under dist/.
+
+Collects all agent registry example records, bundles them into a single
+manifest artifact in dist/, and writes a SHA-256 checksum alongside it.
+
+This is a DRY-RUN only.
+  - No artifact is published to any release channel.
+  - No Homebrew formula URL or checksum is generated for production use.
+  - No credentials, tokens, or secrets are used.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DIST = ROOT / "dist"
+
+DRY_RUN_VERSION = "0.0.0-dry-run"
+
+EXAMPLES = [
+    ROOT / "examples" / "agent-spec.example.json",
+    ROOT / "examples" / "tool-grant.example.json",
+    ROOT / "examples" / "session-authority.example.json",
+    ROOT / "examples" / "revocation-record.example.json",
+    ROOT / "examples" / "professional-intelligence" / "agent-specs.example.json",
+    ROOT / "examples" / "professional-intelligence" / "tool-grants.example.json",
+    ROOT / "examples" / "professional-intelligence" / "session-authority.example.json",
+    ROOT / "examples" / "professional-intelligence" / "revocation-record.example.json",
+]
+
+
+def load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def collect_records() -> list[dict[str, Any]]:
+    """Return a flat list of all agent registry records from the example files."""
+    records: list[dict[str, Any]] = []
+    for path in EXAMPLES:
+        doc = load(path)
+        if isinstance(doc, list):
+            records.extend(doc)
+        else:
+            records.append(doc)
+    return records
+
+
+def build_manifest(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "apiVersion": "agentregistry.socioprophet.dev/v1",
+        "kind": "ReleaseDryRunManifest",
+        "metadata": {
+            "version": DRY_RUN_VERSION,
+            "note": (
+                "dry-run only — not a stable release; "
+                "no Homebrew URL or checksum here is valid for production use"
+            ),
+        },
+        "records": records,
+    }
+
+
+def sha256_of(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    DIST.mkdir(parents=True, exist_ok=True)
+
+    records = collect_records()
+    manifest = build_manifest(records)
+
+    artifact_name = f"agent-registry-{DRY_RUN_VERSION}.json"
+    artifact_path = DIST / artifact_name
+    checksum_path = DIST / f"{artifact_name}.sha256"
+
+    # Serialize deterministically: sorted keys, consistent indentation, UTF-8
+    artifact_bytes = (
+        json.dumps(manifest, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    ).encode("utf-8")
+
+    artifact_path.write_bytes(artifact_bytes)
+    digest = sha256_of(artifact_bytes)
+    checksum_path.write_text(f"{digest}  {artifact_name}\n", encoding="utf-8")
+
+    print(f"dist: {artifact_path.relative_to(ROOT)}")
+    print(f"sha256: {checksum_path.relative_to(ROOT)}")
+    print(f"digest: {digest}")
+    print("OK: release dry-run complete — no production release published")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_release_dry_run.py
+++ b/tools/tests/test_release_dry_run.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools" / "release_dry_run.py"
+DIST = ROOT / "dist"
+
+
+def _run_dry_run():
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_release_dry_run_exits_zero() -> None:
+    result = _run_dry_run()
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_release_dry_run_prints_ok() -> None:
+    result = _run_dry_run()
+    assert "OK: release dry-run complete" in result.stdout
+    assert "no production release published" in result.stdout
+
+
+def test_release_dry_run_emits_artifact_and_checksum() -> None:
+    _run_dry_run()
+    artifact = DIST / "agent-registry-0.0.0-dry-run.json"
+    checksum = DIST / "agent-registry-0.0.0-dry-run.json.sha256"
+    assert artifact.exists()
+    assert checksum.exists()
+
+
+def test_release_dry_run_checksum_matches_artifact() -> None:
+    _run_dry_run()
+    artifact = DIST / "agent-registry-0.0.0-dry-run.json"
+    checksum_file = DIST / "agent-registry-0.0.0-dry-run.json.sha256"
+    expected_digest = checksum_file.read_text(encoding="utf-8").strip().split()[0]
+    actual_digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    assert actual_digest == expected_digest
+
+
+def test_release_dry_run_manifest_structure() -> None:
+    _run_dry_run()
+    artifact = DIST / "agent-registry-0.0.0-dry-run.json"
+    manifest = json.loads(artifact.read_text(encoding="utf-8"))
+
+    assert manifest["apiVersion"] == "agentregistry.socioprophet.dev/v1"
+    assert manifest["kind"] == "ReleaseDryRunManifest"
+    assert manifest["metadata"]["version"] == "0.0.0-dry-run"
+    assert "records" in manifest
+    assert len(manifest["records"]) > 0
+
+
+def test_release_dry_run_manifest_contains_all_kinds() -> None:
+    _run_dry_run()
+    artifact = DIST / "agent-registry-0.0.0-dry-run.json"
+    manifest = json.loads(artifact.read_text(encoding="utf-8"))
+
+    kinds = {record["kind"] for record in manifest["records"]}
+    assert "AgentSpec" in kinds
+    assert "ToolGrant" in kinds
+    assert "SessionAuthority" in kinds
+    assert "RevocationRecord" in kinds
+
+
+def test_release_dry_run_is_deterministic() -> None:
+    _run_dry_run()
+    artifact = DIST / "agent-registry-0.0.0-dry-run.json"
+    first_digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+
+    _run_dry_run()
+    second_digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+
+    assert first_digest == second_digest
+
+
+def test_release_dry_run_note_excludes_homebrew_production_claim() -> None:
+    _run_dry_run()
+    artifact = DIST / "agent-registry-0.0.0-dry-run.json"
+    manifest = json.loads(artifact.read_text(encoding="utf-8"))
+
+    note = manifest["metadata"]["note"].lower()
+    assert "dry-run" in note
+    assert "not a stable release" in note or "no homebrew url" in note.replace("-", " ")


### PR DESCRIPTION
Closed as superseded/already integrated.

The clean release dry-run files are already present on `main`, and the generated `.pyc` artifact is not present on `main`. No further merge is needed from this replacement PR.