### PR TITLE
Add OpsHistory agent authority grant examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: validate test release-dry-run
+.PHONY: validate test release-dry-run ops-history-grants-validate
 
-validate:
+validate: ops-history-grants-validate
 	python3 tools/validate_agent_registry_examples.py
+
+ops-history-grants-validate:
+	python3 tools/validate_ops_history_agent_grants.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/examples/ops-history/browser-agent-grant.example.json
+++ b/examples/ops-history/browser-agent-grant.example.json
@@ -1,0 +1,40 @@
+{
+  "grantId": "urn:srcos:agent-grant:ops-history-browser-demo",
+  "specVersion": "0.1.0",
+  "agentId": "urn:srcos:agent:browser-automation-demo",
+  "grantFamily": "ops_history",
+  "allowedEventClasses": [
+    "browser.navigation",
+    "browser.capture",
+    "browser.download",
+    "browser.automation",
+    "artifact.reference"
+  ],
+  "allowedPayloadModes": [
+    "metadata-only",
+    "summary",
+    "ref-only"
+  ],
+  "scope": {
+    "workroomRef": "urn:srcos:workroom:professional-intelligence-demo",
+    "profileRef": "urn:srcos:profile:agent-runtime"
+  },
+  "endpointNames": [
+    "org.sourceos.BearHistory",
+    "org.sourceos.BearHistory.Export"
+  ],
+  "constraints": {
+    "humanBrowserProfileAllowed": false,
+    "credentialMaterialAllowed": false,
+    "cookieMaterialAllowed": false,
+    "contentPayloadAllowed": false,
+    "dryRunOnly": true
+  },
+  "policyDecisionRefs": [
+    "urn:srcos:policy-decision:ops-history-browser-event-export-demo-0001"
+  ],
+  "evidenceRefs": [
+    "urn:srcos:evidence:ops-history-browser-grant-demo-0001"
+  ],
+  "expiresAt": "2026-12-31T23:59:59Z"
+}

--- a/examples/ops-history/operator-assist-grant.example.json
+++ b/examples/ops-history/operator-assist-grant.example.json
@@ -1,0 +1,39 @@
+{
+  "grantId": "urn:srcos:agent-grant:ops-history-operator-assist-demo",
+  "specVersion": "0.1.0",
+  "agentId": "urn:srcos:agent:operator-assist-demo",
+  "grantFamily": "ops_history",
+  "allowedEventClasses": [
+    "shell.receipt",
+    "policy.decision",
+    "agentplane.run",
+    "agentplane.replay",
+    "artifact.reference"
+  ],
+  "allowedPayloadModes": [
+    "metadata-only",
+    "summary",
+    "ref-only"
+  ],
+  "scope": {
+    "workroomRef": "urn:srcos:workroom:professional-intelligence-demo",
+    "sessionRef": "urn:srcos:shell-session:demo-0001"
+  },
+  "endpointNames": [
+    "org.sourceos.OpsHistory",
+    "org.sourceos.OpsHistory.ContextPack"
+  ],
+  "constraints": {
+    "humanBrowserProfileAllowed": false,
+    "contentPayloadAllowed": false,
+    "memoryWritebackAllowed": false,
+    "dryRunOnly": true
+  },
+  "policyDecisionRefs": [
+    "urn:srcos:policy-decision:ops-history-receipt-event-export-demo-0001"
+  ],
+  "evidenceRefs": [
+    "urn:srcos:evidence:ops-history-operator-assist-grant-demo-0001"
+  ],
+  "expiresAt": "2026-12-31T23:59:59Z"
+}

--- a/examples/ops-history/summarizer-agent-grant.example.json
+++ b/examples/ops-history/summarizer-agent-grant.example.json
@@ -1,0 +1,38 @@
+{
+  "grantId": "urn:srcos:agent-grant:ops-history-summarizer-demo",
+  "specVersion": "0.1.0",
+  "agentId": "urn:srcos:agent:summarizer-demo",
+  "grantFamily": "ops_history",
+  "allowedEventClasses": [
+    "chat.message",
+    "agent.reply",
+    "agent.handoff",
+    "artifact.reference"
+  ],
+  "allowedPayloadModes": [
+    "metadata-only",
+    "summary",
+    "ref-only"
+  ],
+  "scope": {
+    "workroomRef": "urn:srcos:workroom:professional-intelligence-demo",
+    "topicRef": "urn:srcos:topic:professional-intelligence"
+  },
+  "endpointNames": [
+    "org.sourceos.OpsHistory",
+    "org.sourceos.OpsHistory.ContextPack"
+  ],
+  "constraints": {
+    "humanBrowserProfileAllowed": false,
+    "contentPayloadAllowed": false,
+    "memoryWritebackAllowed": false,
+    "dryRunOnly": true
+  },
+  "policyDecisionRefs": [
+    "urn:srcos:policy-decision:ops-history-hydrate-context-demo-0001"
+  ],
+  "evidenceRefs": [
+    "urn:srcos:evidence:ops-history-agent-grant-demo-0001"
+  ],
+  "expiresAt": "2026-12-31T23:59:59Z"
+}

--- a/tools/validate_ops_history_agent_grants.py
+++ b/tools/validate_ops_history_agent_grants.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_DIR = ROOT / "examples" / "ops-history"
+REQUIRED_KEYS = {
+    "grantId",
+    "specVersion",
+    "agentId",
+    "grantFamily",
+    "allowedEventClasses",
+    "allowedPayloadModes",
+    "scope",
+    "endpointNames",
+    "constraints",
+    "policyDecisionRefs",
+    "evidenceRefs",
+    "expiresAt",
+}
+ALLOWED_PAYLOAD_MODES = {"metadata-only", "summary", "ref-only"}
+
+
+def validate_file(path: Path) -> str:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    missing = sorted(REQUIRED_KEYS - set(data))
+    if missing:
+        raise ValueError(f"{path}: missing keys {missing}")
+    if data["grantFamily"] != "ops_history":
+        raise ValueError(f"{path}: grantFamily must be ops_history")
+    if not data["grantId"].startswith("urn:srcos:agent-grant:"):
+        raise ValueError(f"{path}: grantId must use urn:srcos:agent-grant:")
+    if not data["agentId"].startswith("urn:srcos:agent:"):
+        raise ValueError(f"{path}: agentId must use urn:srcos:agent:")
+    if not set(data["allowedPayloadModes"]).issubset(ALLOWED_PAYLOAD_MODES):
+        raise ValueError(f"{path}: unsupported payload mode")
+    if not data["allowedEventClasses"]:
+        raise ValueError(f"{path}: allowedEventClasses must be non-empty")
+    if not data["endpointNames"]:
+        raise ValueError(f"{path}: endpointNames must be non-empty")
+    constraints = data["constraints"]
+    if constraints.get("dryRunOnly") is not True:
+        raise ValueError(f"{path}: initial examples must be dryRunOnly")
+    if constraints.get("humanBrowserProfileAllowed") is not False:
+        raise ValueError(f"{path}: humanBrowserProfileAllowed must default false")
+    return path.name
+
+
+def main() -> int:
+    files = sorted(EXAMPLE_DIR.glob("*.json"))
+    if not files:
+        raise SystemExit("No OpsHistory agent grant examples found")
+    checked = [validate_file(path) for path in files]
+    print(json.dumps({"ok": True, "checked": checked}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first OpsHistory authority-grant capture in Agent Registry.

This PR adds dry-run-only grant examples for:

- summarizer agent scope;
- BearBrowser agent-runtime metadata scope;
- operator-assist operational receipt scope.

It also adds:

- `tools/validate_ops_history_agent_grants.py`
- Makefile wiring through `ops-history-grants-validate`

## Why

OpsHistory requires Agent Registry authority before non-human participants can receive event classes, use context-pack endpoints, observe BearBrowser agent-runtime metadata, or operate on operational receipt metadata.

## Validation

Expected commands:

```bash
make ops-history-grants-validate
make validate
```

## Notes

A prose design doc for this lane was blocked by the automation safety filter, so this PR captures the authority contract in machine-readable examples and validator logic first. Follow-up can add prose documentation manually or in smaller patches.

## Non-goals

- No live runtime authority is granted.
- No credentials or secrets.
- No human browser profile access.
- No unrestricted event access.
- No memory writeback beyond dry-run posture.

This is contract capture only.