### PR TITLE
Add Identity Prime minimal agent manifests

### DIFF
--- a/protocol/agent-manifest/acr-concordance-agent.json
+++ b/protocol/agent-manifest/acr-concordance-agent.json
@@ -1,0 +1,11 @@
+{
+  "agent_id": "acr-concordance-agent",
+  "version": "0.1.0",
+  "role": "golden_record_concordance_submission",
+  "inputs": ["SourceRecord", "ConcordanceLink", "CanonicalEntity"],
+  "outputs": ["ConcordanceDecisionCertificate"],
+  "policy_scopes": ["acr.survivorship.core@0.1.0"],
+  "graph_permissions": ["read:source_record", "read:canonical_entity", "read:concordance_link"],
+  "search_permissions": [],
+  "evidence_outputs": ["ledger_pointer", "certificate_pointer"]
+}

--- a/protocol/agent-manifest/holmes-case-agent.json
+++ b/protocol/agent-manifest/holmes-case-agent.json
@@ -1,0 +1,11 @@
+{
+  "agent_id": "holmes-case-agent",
+  "version": "0.1.0",
+  "role": "investigation_case_reasoning",
+  "inputs": ["MeshRushSimulationTrace", "IdentityState", "ProofCertificate"],
+  "outputs": ["InvestigationCase"],
+  "policy_scopes": ["regis.transition.admissibility.core@0.1.0"],
+  "graph_permissions": ["read:identity_state", "read:mesh_rush_trace"],
+  "search_permissions": [],
+  "evidence_outputs": ["ledger_pointer", "certificate_pointer", "trace_pointer"]
+}

--- a/protocol/agent-manifest/meshrush-simulation-agent.json
+++ b/protocol/agent-manifest/meshrush-simulation-agent.json
@@ -1,0 +1,11 @@
+{
+  "agent_id": "meshrush-simulation-agent",
+  "version": "0.1.0",
+  "role": "graph_exploration",
+  "inputs": ["IdentityState", "TokenLane", "ProofCertificate"],
+  "outputs": ["MeshRushSimulationTrace"],
+  "policy_scopes": ["regis.transition.admissibility.core@0.1.0"],
+  "graph_permissions": ["read:identity_state", "read:token_lane"],
+  "search_permissions": [],
+  "evidence_outputs": ["trace_pointer"]
+}

--- a/protocol/agent-manifest/regis-proof-agent.json
+++ b/protocol/agent-manifest/regis-proof-agent.json
@@ -1,0 +1,11 @@
+{
+  "agent_id": "regis-proof-agent",
+  "version": "0.1.0",
+  "role": "proof_generation",
+  "inputs": ["IdentityState", "ConcordanceLink", "CanonicalEntity"],
+  "outputs": ["ProofCertificate"],
+  "policy_scopes": ["regis.identity.polytope.core@0.1.0"],
+  "graph_permissions": ["read:identity_state", "read:concordance_link"],
+  "search_permissions": [],
+  "evidence_outputs": ["ledger_pointer", "certificate_pointer"]
+}

--- a/protocol/agent-manifest/sherlock-index-agent.json
+++ b/protocol/agent-manifest/sherlock-index-agent.json
@@ -1,0 +1,11 @@
+{
+  "agent_id": "sherlock-index-agent",
+  "version": "0.1.0",
+  "role": "pointer_backed_evidence_indexing",
+  "inputs": ["InvestigationCase", "MeshRushSimulationTrace", "ProofCertificate"],
+  "outputs": ["SearchIndexRecord"],
+  "policy_scopes": ["regis.search.evidence_pointer.core@0.1.0"],
+  "graph_permissions": [],
+  "search_permissions": ["write:search_index_record", "read:search_query_result"],
+  "evidence_outputs": ["ledger_pointer", "certificate_pointer", "trace_pointer"]
+}


### PR DESCRIPTION
## Summary

Adds the five minimal agent manifests for Sociosphere Identity Is Prime conformance lane:

- `regis-proof-agent`
- `meshrush-simulation-agent`
- `holmes-case-agent`
- `sherlock-index-agent`
- `acr-concordance-agent`

These manifests include inputs, outputs, policy scopes, graph/search permissions, and evidence outputs sufficient to run the Sociosphere reference-runner.

## Acceptance

- Verified execution with Sociosphere reference-runner (issue #287) successful.
- All agents produce expected artifacts for fixtures: polytope, transition, token non-escape, MeshRush simulation, Holmes case, Sherlock search, ACR proof, and zeta/audit.

## Related

- Sociosphere issue #287
- Sociosphere PR #286