### PR TITLE
docs(control-plane): define grants and runtime authority boundary

### DIFF
--- a/docs/control-plane-grants-and-runtime-authority.md
+++ b/docs/control-plane-grants-and-runtime-authority.md
@@ -1,0 +1,44 @@
+# Control-Plane Grants and Runtime Authority
+
+This document records the Agent Registry side of the Matrix / MCP / A2A / capability-lease control-plane slice.
+
+## Role
+
+Agent Registry is the canonical registry for:
+
+- agent specifications,
+- agent identities,
+- sessions,
+- tool grants,
+- grant revocation,
+- and runtime authority records.
+
+It does not own broker enforcement, deployment topology, Matrix room policy, or execution runtime.
+
+## Boundary split
+
+- `agent-registry` owns grant and authority records.
+- `mcp-a2a-zero-trust` consumes grant and authority records for broker enforcement and zero-trust boundary checks.
+- `HolographMe` owns human delegation, consent, and acting-for-human authority semantics.
+- `agentplane` owns execution admission and run/replay evidence once work is proposed for execution.
+- `policy-fabric` owns policy approvals and compiled policy evidence.
+
+## Control-plane grant requirements
+
+A control-plane grant record should include:
+
+- stable grant identifier,
+- subject agent,
+- allowed capability or tool scope,
+- authority class,
+- optional human delegation reference,
+- optional policy reference,
+- optional admission reference,
+- revocation status,
+- and expiry or renewal posture.
+
+## Non-goals
+
+This tranche does not implement broker enforcement.
+
+The broker/enforcement implementation belongs in `mcp-a2a-zero-trust` and should consume Agent Registry decisions rather than redefine them.

--- a/examples/control-plane-capability-grant.example.json
+++ b/examples/control-plane-capability-grant.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1.0",
+  "grant_id": "grant_control_plane_matrix_triage_001",
+  "subject_agent": "agent://matrix-triage-assistant",
+  "authority_class": "tool_grant",
+  "allowed_scopes": [
+    "matrix.room.read",
+    "case.intake.summarize",
+    "support.ticket.propose"
+  ],
+  "denied_scopes": [
+    "case.record.mutate",
+    "matrix.room.publish",
+    "production.deploy"
+  ],
+  "runtime_authority": {
+    "state": "active",
+    "expires_at": "2026-05-07T23:59:59Z",
+    "revoked": false,
+    "revocation_reason": null
+  },
+  "policy_ref": "policy-fabric://control-plane/matrix-triage-readonly-v0",
+  "delegation_ref": null,
+  "admission_ref": null,
+  "notes": "Read-only public-intake grant fixture. Broker enforcement belongs in mcp-a2a-zero-trust. Execution admission, when needed, belongs in agentplane."
+}


### PR DESCRIPTION
## Summary

Add the Agent Registry side of the Matrix / MCP / A2A / capability-lease control-plane slice.

### Added
- `docs/control-plane-grants-and-runtime-authority.md`
- `examples/control-plane-capability-grant.example.json`

## Why

Recent upstream work makes Agent Registry the canonical home for agent specs, identities, sessions, grants, revocation, and runtime authority.

The control-plane split should therefore treat:
- `agent-registry` as the grant and runtime-authority registry,
- `mcp-a2a-zero-trust` as the broker/enforcement and zero-trust boundary,
- `HolographMe` as the human delegation / consent authority,
- `agentplane` as the execution admission and run/replay evidence surface,
- and `policy-fabric` as the policy approval / compiled evidence surface.

## Boundary

This PR does **not** implement broker enforcement.

It defines the Agent Registry ownership lane and adds a minimal read-only control-plane grant fixture. Broker enforcement should consume these records from `mcp-a2a-zero-trust` rather than redefine grant authority there.

## Follow-on order

1. `mcp-a2a-zero-trust` — consume Agent Registry grants and enforce broker/policy/attestation boundary
2. `prophet-platform` — runtime/deployment skeleton
3. `policy-fabric` — governed consumer integration
