### PR TITLE
Register Noetica surface-agent stub

### DIFF
--- a/agents/noetica/README.md
+++ b/agents/noetica/README.md
@@ -1,0 +1,27 @@
+# Noetica Agent Stub
+
+This directory registers Noetica as a registry-visible surface agent for the SocioProphet / SourceOS stack.
+
+Status: `registry-stub`.
+
+This is not a production admission. It does not grant live provider access, does not store credentials, and does not admit sessions, memories, or runtime tool grants.
+
+## Authority
+
+- Authority repository: `SocioProphet/Noetica`
+- Registry authority: `SocioProphet/agent-registry`
+- Route evidence authority: `SocioProphet/agentplane`
+
+## Required future grants
+
+The manifest declares future grant dependencies only:
+
+- `call:anthropic`
+- `call:openai`
+- `call:neuronpedia:steer`
+
+Each grant is marked `not-admitted`. Production SourceOS mode must resolve grants through agent-registry before Noetica may use them as governed runtime authority.
+
+## Boundary
+
+Standalone Noetica may use runtime environment variables outside the registry. SourceOS mode must migrate provider access to governed grant resolution. This directory makes that future boundary explicit without pretending the grant already exists.

--- a/agents/noetica/manifest.json
+++ b/agents/noetica/manifest.json
@@ -1,0 +1,97 @@
+{
+  "agent_id": "noetica",
+  "display_name": "Noetica",
+  "version": "m2a-registry-stub",
+  "authority_repo": "SocioProphet/Noetica",
+  "agent_class": "surface",
+  "trust_level": "surface",
+  "admission_status": "registry-stub",
+  "production_admitted": false,
+  "standalone_mode": true,
+  "sourceos_mode": false,
+  "description": "Governed chat surface for SocioProphet / SourceOS. This stub declares Noetica as a registry-visible surface agent without admitting production runtime authority.",
+  "modes": {
+    "standalone": {
+      "available": true,
+      "credential_source": "runtime-environment",
+      "registry_grants_enforced": false,
+      "notes": "Standalone mode may use local runtime environment variables. The registry does not store credentials."
+    },
+    "sourceos": {
+      "available": false,
+      "credential_source": "agent-registry-tool-grant-resolution-pending",
+      "registry_grants_enforced": true,
+      "notes": "SourceOS mode must resolve provider and steering grants through agent-registry before production admission."
+    }
+  },
+  "tool_grants_required": [
+    {
+      "grant_id": "call:anthropic",
+      "grant_status": "not-admitted",
+      "capability": "external-model-provider-route",
+      "credential_stored_here": false,
+      "evidence_required": "ExternalModelProviderRouteEvidence"
+    },
+    {
+      "grant_id": "call:openai",
+      "grant_status": "not-admitted",
+      "capability": "external-model-provider-route",
+      "credential_stored_here": false,
+      "evidence_required": "ExternalModelProviderRouteEvidence"
+    },
+    {
+      "grant_id": "call:neuronpedia:steer",
+      "grant_status": "not-admitted",
+      "capability": "sae-steering-provider-route",
+      "credential_stored_here": false,
+      "evidence_required": "ExternalModelProviderRouteEvidence"
+    }
+  ],
+  "authority_boundaries": {
+    "owns": [
+      "chat-surface",
+      "steering-ux",
+      "governance-trail-display",
+      "provider-abstraction-view"
+    ],
+    "does_not_own": [
+      "memory-persistence",
+      "model-routing-authority",
+      "policy-admission-authority",
+      "tool-grant-admission",
+      "credential-storage"
+    ],
+    "delegated_authorities": {
+      "memory": "SocioProphet/memory-mesh",
+      "model_routing": "SocioProphet/model-router",
+      "policy_admission": "SocioProphet/guardrail-fabric",
+      "tool_grants": "SocioProphet/agent-registry",
+      "route_evidence": "SocioProphet/agentplane"
+    }
+  },
+  "evidence_boundaries": {
+    "standalone_current": [
+      "request_hash",
+      "evidence_hash",
+      "provider_route_evidence"
+    ],
+    "sourceos_future": [
+      "agent-registry-grant-ref",
+      "agentplane-route-evidence-ref",
+      "superconscious-run-ref"
+    ],
+    "credential_material_allowed": false,
+    "prompt_or_completion_storage_required": false
+  },
+  "revocation": {
+    "revocable": true,
+    "revocation_record_required": true,
+    "revocation_authority": "SocioProphet/agent-registry"
+  },
+  "non_claims": [
+    "This stub is not production admission.",
+    "This stub does not grant live provider access.",
+    "This stub does not store credentials or secrets.",
+    "This stub does not admit sessions, memories, or runtime tool grants."
+  ]
+}


### PR DESCRIPTION
Closes #32.

## Summary

Adds a non-production Noetica surface-agent registry stub under `agents/noetica/`.

## What changed

- Added `agents/noetica/manifest.json`.
- Added `agents/noetica/README.md`.
- Declares Noetica authority repo: `SocioProphet/Noetica`.
- Declares Noetica as a surface agent with `admission_status: registry-stub` and `production_admitted: false`.
- Declares future tool-grant dependencies by name only.
- Marks each future grant as `not-admitted` and `credential_stored_here: false`.
- Documents standalone mode as available through runtime environment fallback.
- Documents SourceOS mode as not yet admitted and pending governed grant resolution.
- Records authority, evidence, revocation, and non-claim boundaries.

## Validation

Native CI passed on this PR head:

- `validate` run #52: passed
  - Install test dependency
  - Validate examples
  - Run tests
- `release-dry-run` run #41: passed
  - Validate examples
  - Release dry-run
  - Verify checksum
  - Upload dry-run artifacts

## Known gaps

- This does not admit Noetica to production.
- This does not grant live provider access.
- This does not store credentials.
- This does not admit sessions, memories, or runtime tool grants.
- Future PRs should bind this stub to formal schemas when agent-registry exposes repo-native manifest validation.