### PR TITLE
Replay workspace-operations agent registry records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: validate test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops
 	python3 tools/validate_agent_registry_examples.py
+
+validate-workspace-ops:
+	python3 tools/validate_workspace_operation_records.py
 
 ops-history-grants-validate:
 	python3 tools/validate_ops_history_agent_grants.py

--- a/contracts/workspace-operations/records.v0.1.schema.json
+++ b/contracts/workspace-operations/records.v0.1.schema.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/workspace-operations/records.v0.1.schema.json",
+  "title": "Agent Registry Workspace Operation Records v0.1",
+  "description": "Schema covering all agent registry record kinds required for Workspace Operation Plane integration.",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+    "kind": {
+      "type": "string",
+      "enum": [
+        "AgentRegistration",
+        "AgentCapabilityDeclaration",
+        "AgentOperationScope",
+        "AgentDelegationGrant",
+        "AgentToolGrant",
+        "AgentBudgetPolicy",
+        "AgentAuditProfile",
+        "AgentRevocationRecord",
+        "AgentOperationSessionBinding"
+      ]
+    },
+    "metadata": {"type": "object"},
+    "spec": {"type": "object"}
+  },
+  "$defs": {
+    "AgentRegistration": {
+      "description": "Root identity record for an agent in the Workspace Operation Plane.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentRegistration"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "agentKind", "version"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "agentKind": {"type": "string", "enum": ["codex", "copilot", "human", "local-cli", "system"]},
+            "version": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["ownerRef", "policyProfile", "revocationState", "evidenceRef", "revocationRef"],
+          "properties": {
+            "ownerRef": {"type": "string"},
+            "policyProfile": {"type": "string"},
+            "revocationState": {"type": "string", "enum": ["active", "revoked", "suspended"]},
+            "evidenceRef": {"type": "string"},
+            "revocationRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentCapabilityDeclaration": {
+      "description": "Declares the operation types, tools, and artifact types an agent is permitted to use.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentCapabilityDeclaration"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["declarationId", "agentId"],
+          "properties": {
+            "declarationId": {"type": "string"},
+            "agentId": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "allowedOperationTypes", "allowedTools", "allowedArtifactTypes", "policyProfile", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "allowedOperationTypes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "allowedTools": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "allowedArtifactTypes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "policyProfile": {"type": "string"},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentOperationScope": {
+      "description": "Constrains the set of operation types and artifact types an agent may act upon in a given scope.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentOperationScope"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["scopeId", "agentId"],
+          "properties": {
+            "scopeId": {"type": "string"},
+            "agentId": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "allowedOperationTypes", "allowedArtifactTypes", "policyProfile", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "allowedOperationTypes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "allowedArtifactTypes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "policyProfile": {"type": "string"},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentDelegationGrant": {
+      "description": "A scoped, expiring, revocable delegation of operation authority from one agent to another.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentDelegationGrant"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["grantId", "agentId"],
+          "properties": {
+            "grantId": {"type": "string"},
+            "agentId": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "delegatedBy", "allowedOperationTypes", "allowedArtifactTypes", "policyProfile", "expiresAt", "revocationState", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "delegatedBy": {"type": "string"},
+            "allowedOperationTypes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "allowedArtifactTypes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "policyProfile": {"type": "string"},
+            "expiresAt": {"type": "string"},
+            "revocationState": {"type": "string", "enum": ["active", "revoked", "expired"]},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentToolGrant": {
+      "description": "Grants specific tools to an agent with scope constraints and an expiration.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentToolGrant"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["grantId", "agentId"],
+          "properties": {
+            "grantId": {"type": "string"},
+            "agentId": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "allowedTools", "scope", "constraints", "expiresAt", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "allowedTools": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "scope": {"type": "string"},
+            "constraints": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "expiresAt": {"type": "string"},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentBudgetPolicy": {
+      "description": "Defines token, operation, and artifact budgets plus concurrency limits for an agent.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentBudgetPolicy"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["policyId", "agentId"],
+          "properties": {
+            "policyId": {"type": "string"},
+            "agentId": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "defaultBudget", "maxConcurrency", "policyProfile", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "defaultBudget": {
+              "type": "object",
+              "required": ["maxTokensPerOperation", "maxOperationsPerSession", "maxArtifactsPerOperation"],
+              "properties": {
+                "maxTokensPerOperation": {"type": "integer", "minimum": 1},
+                "maxOperationsPerSession": {"type": "integer", "minimum": 1},
+                "maxArtifactsPerOperation": {"type": "integer", "minimum": 1}
+              }
+            },
+            "maxConcurrency": {"type": "integer", "minimum": 1},
+            "policyProfile": {"type": "string"},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentAuditProfile": {
+      "description": "Specifies the audit level and policy profile for an agent in the Workspace Operation Plane.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentAuditProfile"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["profileId", "agentId"],
+          "properties": {
+            "profileId": {"type": "string"},
+            "agentId": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "auditLevel", "policyProfile", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "auditLevel": {"type": "string", "enum": ["none", "summary", "standard", "full"]},
+            "policyProfile": {"type": "string"},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentRevocationRecord": {
+      "description": "Records the revocation state for a workspace-operations agent, including revoked operation types and tools.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentRevocationRecord"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["revocationId", "agentId", "createdAt"],
+          "properties": {
+            "revocationId": {"type": "string"},
+            "agentId": {"type": "string"},
+            "createdAt": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "revocationState", "revokedOperationTypes", "revokedTools", "reasonCodes", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "revocationState": {"type": "string", "enum": ["not-revoked", "revoked"]},
+            "revokedOperationTypes": {"type": "array", "items": {"type": "string"}},
+            "revokedTools": {"type": "array", "items": {"type": "string"}},
+            "reasonCodes": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    },
+    "AgentOperationSessionBinding": {
+      "description": "Binds an active agent session to its operation scope, delegation grant, tool grants, budget, and audit profile.",
+      "type": "object",
+      "required": ["apiVersion", "kind", "metadata", "spec"],
+      "additionalProperties": false,
+      "properties": {
+        "apiVersion": {"const": "agentregistry.socioprophet.dev/v1"},
+        "kind": {"const": "AgentOperationSessionBinding"},
+        "metadata": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sessionId", "agentId", "createdAt"],
+          "properties": {
+            "sessionId": {"type": "string"},
+            "agentId": {"type": "string"},
+            "createdAt": {"type": "string"}
+          }
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agentId", "operationScopeRef", "toolGrantRefs", "budgetPolicyRef", "auditProfileRef", "status", "evidenceRef"],
+          "properties": {
+            "agentId": {"type": "string"},
+            "operationScopeRef": {"type": "string"},
+            "delegationGrantRef": {"type": "string"},
+            "toolGrantRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "budgetPolicyRef": {"type": "string"},
+            "auditProfileRef": {"type": "string"},
+            "status": {"type": "string", "enum": ["active", "expired", "revoked"]},
+            "evidenceRef": {"type": "string"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/workspace-operations-registry.md
+++ b/docs/workspace-operations-registry.md
@@ -1,0 +1,88 @@
+# Workspace Operations Registry
+
+## Purpose
+
+Extend Agent Registry so every agent action in the Workspace Operation Plane has registered identity, declared capabilities, scoped delegation, budgets, policy profile, audit level, and revocation state.
+
+No agent receives workspace authority from presence alone. Authority must be registered, delegated, scoped, policy-checked, budgeted, and revocable.
+
+## Hard rule
+
+> AgentPlane must check this registry before any agent command touches: WorkspaceOperation, OperationTask, Artifact, DecisionCard, PolicyGateRecord, ToolGrant, Memory namespace, or Local agent-machine execution.
+
+## Record kinds
+
+| Kind | Description |
+|---|---|
+| `AgentRegistration` | Root identity record. Links agent to owner, policy profile, and revocation anchor. |
+| `AgentCapabilityDeclaration` | Declares allowed operation types, tools, and artifact types. |
+| `AgentOperationScope` | Constrains operation types and artifact types the agent may act upon in a given scope. |
+| `AgentDelegationGrant` | Scoped, expiring, revocable delegation of operation authority from one agent to another. |
+| `AgentToolGrant` | Grants specific tools with scope constraints and an expiration. Requires `evidence-required` constraint. |
+| `AgentBudgetPolicy` | Token, operation, and artifact budgets plus `maxConcurrency`. |
+| `AgentAuditProfile` | Audit level (`none` / `summary` / `standard` / `full`) and policy profile. |
+| `AgentRevocationRecord` | Revocation state for the agent, including revoked operation types and tools. |
+| `AgentOperationSessionBinding` | Binds an active session to its scope, delegation grant, tool grants, budget, and audit profile. |
+
+## Required fields summary
+
+| Field | Records |
+|---|---|
+| `agentId` | All |
+| `ownerRef` | AgentRegistration |
+| `version` | AgentRegistration metadata |
+| `allowedOperationTypes` | AgentCapabilityDeclaration, AgentOperationScope, AgentDelegationGrant |
+| `allowedTools` | AgentCapabilityDeclaration, AgentToolGrant |
+| `allowedArtifactTypes` | AgentCapabilityDeclaration, AgentOperationScope, AgentDelegationGrant |
+| `defaultBudget` | AgentBudgetPolicy |
+| `maxConcurrency` | AgentBudgetPolicy |
+| `policyProfile` | AgentRegistration, AgentCapabilityDeclaration, AgentOperationScope, AgentDelegationGrant, AgentBudgetPolicy, AgentAuditProfile |
+| `auditLevel` | AgentAuditProfile |
+| `revocationState` | AgentRegistration, AgentDelegationGrant, AgentRevocationRecord |
+| `delegatedBy` | AgentDelegationGrant |
+| `expiresAt` | AgentDelegationGrant, AgentToolGrant |
+
+## Contract files
+
+- `contracts/workspace-operations/records.v0.1.schema.json`
+- `examples/workspace-operations/agent-registrations.example.json`
+- `examples/workspace-operations/capability-declarations.example.json`
+- `examples/workspace-operations/operation-scopes.example.json`
+- `examples/workspace-operations/delegation-grants.example.json`
+- `examples/workspace-operations/tool-grants.example.json`
+- `examples/workspace-operations/budget-policies.example.json`
+- `examples/workspace-operations/audit-profiles.example.json`
+- `examples/workspace-operations/revocation-records.example.json`
+- `examples/workspace-operations/session-bindings.example.json`
+
+## Validation
+
+```bash
+make validate
+make validate-workspace-ops
+make test
+```
+
+## Invariants
+
+- Every `AgentRegistration` must have a `revocationRef` that points to an existing `AgentRevocationRecord`.
+- Every `AgentToolGrant` must include the `evidence-required` constraint.
+- Every `AgentDelegationGrant` must have `delegatedBy`, `expiresAt`, and `revocationState`.
+- Every `AgentOperationSessionBinding` must reference a registered agent, an existing `AgentOperationScope`, and at least one existing `AgentToolGrant`.
+- `AgentBudgetPolicy.maxConcurrency` must be a positive integer.
+- `AgentAuditProfile.auditLevel` must be one of: `none`, `summary`, `standard`, `full`.
+
+## Non-goals
+
+- Agent Registry is not the policy engine.
+- Agent Registry is not the execution plane.
+- Agent Registry must not store credentials, tokens, or private prompts.
+- Agent Registry does not decide outcomes; it records authority posture and revocation posture.
+
+## References
+
+- `SocioProphet/agentplane#85`
+- `SocioProphet/prophet-core-contracts#1`
+- `SocioProphet/workspace-inventory#3`
+- `SocioProphet/policy-fabric#46`
+- `SourceOS-Linux/agent-machine#18`

--- a/examples/workspace-operations/agent-registrations.example.json
+++ b/examples/workspace-operations/agent-registrations.example.json
@@ -1,0 +1,34 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentRegistration",
+    "metadata": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "agentKind": "codex",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "ownerRef": "team://socioprophet/agentplane",
+      "policyProfile": "policy://workspace-operations/executor-default",
+      "revocationState": "active",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-registration",
+      "revocationRef": "revocation://workspace-operations/ws-ops-executor/current"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentRegistration",
+    "metadata": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "agentKind": "copilot",
+      "version": "0.1.0"
+    },
+    "spec": {
+      "ownerRef": "team://socioprophet/agentplane",
+      "policyProfile": "policy://workspace-operations/reviewer-default",
+      "revocationState": "active",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-registration",
+      "revocationRef": "revocation://workspace-operations/ws-ops-reviewer/current"
+    }
+  }
+]

--- a/examples/workspace-operations/audit-profiles.example.json
+++ b/examples/workspace-operations/audit-profiles.example.json
@@ -1,0 +1,30 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentAuditProfile",
+    "metadata": {
+      "profileId": "audit://workspace-operations/ws-ops-executor/default",
+      "agentId": "agent://workspace-operations/ws-ops-executor"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "auditLevel": "full",
+      "policyProfile": "policy://workspace-operations/executor-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-audit"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentAuditProfile",
+    "metadata": {
+      "profileId": "audit://workspace-operations/ws-ops-reviewer/default",
+      "agentId": "agent://workspace-operations/ws-ops-reviewer"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "auditLevel": "full",
+      "policyProfile": "policy://workspace-operations/reviewer-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-audit"
+    }
+  }
+]

--- a/examples/workspace-operations/budget-policies.example.json
+++ b/examples/workspace-operations/budget-policies.example.json
@@ -1,0 +1,40 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentBudgetPolicy",
+    "metadata": {
+      "policyId": "budget://workspace-operations/ws-ops-executor/default",
+      "agentId": "agent://workspace-operations/ws-ops-executor"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "defaultBudget": {
+        "maxTokensPerOperation": 32000,
+        "maxOperationsPerSession": 50,
+        "maxArtifactsPerOperation": 10
+      },
+      "maxConcurrency": 3,
+      "policyProfile": "policy://workspace-operations/executor-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-budget"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentBudgetPolicy",
+    "metadata": {
+      "policyId": "budget://workspace-operations/ws-ops-reviewer/default",
+      "agentId": "agent://workspace-operations/ws-ops-reviewer"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "defaultBudget": {
+        "maxTokensPerOperation": 16000,
+        "maxOperationsPerSession": 20,
+        "maxArtifactsPerOperation": 5
+      },
+      "maxConcurrency": 1,
+      "policyProfile": "policy://workspace-operations/reviewer-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-budget"
+    }
+  }
+]

--- a/examples/workspace-operations/capability-declarations.example.json
+++ b/examples/workspace-operations/capability-declarations.example.json
@@ -1,0 +1,57 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentCapabilityDeclaration",
+    "metadata": {
+      "declarationId": "declaration://workspace-operations/ws-ops-executor/capabilities",
+      "agentId": "agent://workspace-operations/ws-ops-executor"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "allowedOperationTypes": [
+        "WorkspaceOperation",
+        "OperationTask",
+        "ToolGrant"
+      ],
+      "allowedTools": [
+        "tool://agentplane/workspace-operation-create",
+        "tool://agentplane/operation-task-update",
+        "tool://agentplane/artifact-read"
+      ],
+      "allowedArtifactTypes": [
+        "Artifact",
+        "DecisionCard"
+      ],
+      "policyProfile": "policy://workspace-operations/executor-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-capabilities"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentCapabilityDeclaration",
+    "metadata": {
+      "declarationId": "declaration://workspace-operations/ws-ops-reviewer/capabilities",
+      "agentId": "agent://workspace-operations/ws-ops-reviewer"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "allowedOperationTypes": [
+        "WorkspaceOperation",
+        "DecisionCard",
+        "PolicyGateRecord"
+      ],
+      "allowedTools": [
+        "tool://agentplane/workspace-operation-read",
+        "tool://agentplane/decision-card-create",
+        "tool://agentplane/policy-gate-evaluate"
+      ],
+      "allowedArtifactTypes": [
+        "Artifact",
+        "DecisionCard",
+        "PolicyGateRecord"
+      ],
+      "policyProfile": "policy://workspace-operations/reviewer-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-capabilities"
+    }
+  }
+]

--- a/examples/workspace-operations/delegation-grants.example.json
+++ b/examples/workspace-operations/delegation-grants.example.json
@@ -1,0 +1,25 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentDelegationGrant",
+    "metadata": {
+      "grantId": "grant://workspace-operations/ws-ops-executor/delegated-from-reviewer",
+      "agentId": "agent://workspace-operations/ws-ops-executor"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "delegatedBy": "agent://workspace-operations/ws-ops-reviewer",
+      "allowedOperationTypes": [
+        "WorkspaceOperation",
+        "OperationTask"
+      ],
+      "allowedArtifactTypes": [
+        "Artifact"
+      ],
+      "policyProfile": "policy://workspace-operations/delegated-executor",
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "revocationState": "active",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/delegation-grant-001"
+    }
+  }
+]

--- a/examples/workspace-operations/operation-scopes.example.json
+++ b/examples/workspace-operations/operation-scopes.example.json
@@ -1,0 +1,47 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentOperationScope",
+    "metadata": {
+      "scopeId": "scope://workspace-operations/ws-ops-executor/default",
+      "agentId": "agent://workspace-operations/ws-ops-executor"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "allowedOperationTypes": [
+        "WorkspaceOperation",
+        "OperationTask",
+        "ToolGrant"
+      ],
+      "allowedArtifactTypes": [
+        "Artifact",
+        "DecisionCard"
+      ],
+      "policyProfile": "policy://workspace-operations/executor-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-scope"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentOperationScope",
+    "metadata": {
+      "scopeId": "scope://workspace-operations/ws-ops-reviewer/default",
+      "agentId": "agent://workspace-operations/ws-ops-reviewer"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "allowedOperationTypes": [
+        "WorkspaceOperation",
+        "DecisionCard",
+        "PolicyGateRecord"
+      ],
+      "allowedArtifactTypes": [
+        "Artifact",
+        "DecisionCard",
+        "PolicyGateRecord"
+      ],
+      "policyProfile": "policy://workspace-operations/reviewer-default",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-scope"
+    }
+  }
+]

--- a/examples/workspace-operations/revocation-records.example.json
+++ b/examples/workspace-operations/revocation-records.example.json
@@ -1,0 +1,36 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentRevocationRecord",
+    "metadata": {
+      "revocationId": "revocation://workspace-operations/ws-ops-executor/current",
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "createdAt": "2026-05-01T00:00:00Z"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "revocationState": "not-revoked",
+      "revokedOperationTypes": [],
+      "revokedTools": [],
+      "reasonCodes": ["active-authority"],
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-revocation"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentRevocationRecord",
+    "metadata": {
+      "revocationId": "revocation://workspace-operations/ws-ops-reviewer/current",
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "createdAt": "2026-05-01T00:00:00Z"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "revocationState": "not-revoked",
+      "revokedOperationTypes": [],
+      "revokedTools": [],
+      "reasonCodes": ["active-authority"],
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-revocation"
+    }
+  }
+]

--- a/examples/workspace-operations/session-bindings.example.json
+++ b/examples/workspace-operations/session-bindings.example.json
@@ -1,0 +1,23 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentOperationSessionBinding",
+    "metadata": {
+      "sessionId": "session://workspace-operations/ws-ops-executor/001",
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "createdAt": "2026-05-01T00:00:00Z"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "operationScopeRef": "scope://workspace-operations/ws-ops-executor/default",
+      "delegationGrantRef": "grant://workspace-operations/ws-ops-executor/delegated-from-reviewer",
+      "toolGrantRefs": [
+        "grant://workspace-operations/ws-ops-executor/workspace-operation-create"
+      ],
+      "budgetPolicyRef": "budget://workspace-operations/ws-ops-executor/default",
+      "auditProfileRef": "audit://workspace-operations/ws-ops-executor/default",
+      "status": "active",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-session-001"
+    }
+  }
+]

--- a/examples/workspace-operations/tool-grants.example.json
+++ b/examples/workspace-operations/tool-grants.example.json
@@ -1,0 +1,52 @@
+[
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentToolGrant",
+    "metadata": {
+      "grantId": "grant://workspace-operations/ws-ops-executor/workspace-operation-create",
+      "agentId": "agent://workspace-operations/ws-ops-executor"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-executor",
+      "allowedTools": [
+        "tool://agentplane/workspace-operation-create",
+        "tool://agentplane/operation-task-update",
+        "tool://agentplane/artifact-read"
+      ],
+      "scope": "create-update-read-only",
+      "constraints": [
+        "no-secret-access",
+        "no-memory-namespace-write",
+        "no-local-agent-machine-execution",
+        "evidence-required"
+      ],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-executor-tool-grant"
+    }
+  },
+  {
+    "apiVersion": "agentregistry.socioprophet.dev/v1",
+    "kind": "AgentToolGrant",
+    "metadata": {
+      "grantId": "grant://workspace-operations/ws-ops-reviewer/decision-card-create",
+      "agentId": "agent://workspace-operations/ws-ops-reviewer"
+    },
+    "spec": {
+      "agentId": "agent://workspace-operations/ws-ops-reviewer",
+      "allowedTools": [
+        "tool://agentplane/workspace-operation-read",
+        "tool://agentplane/decision-card-create",
+        "tool://agentplane/policy-gate-evaluate"
+      ],
+      "scope": "read-evaluate-create-only",
+      "constraints": [
+        "no-secret-access",
+        "no-memory-namespace-write",
+        "no-local-agent-machine-execution",
+        "evidence-required"
+      ],
+      "expiresAt": "2026-12-31T23:59:59Z",
+      "evidenceRef": "evidence://agent-registry/workspace-operations/ws-ops-reviewer-tool-grant"
+    }
+  }
+]

--- a/tools/tests/test_workspace_operation_records.py
+++ b/tools/tests/test_workspace_operation_records.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WS_EXAMPLES = ROOT / "examples" / "workspace-operations"
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_workspace_operation_records_validate() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_workspace_operation_records.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: validated" in result.stdout
+
+
+def test_agent_registrations_have_required_fields() -> None:
+    registrations = load_json(WS_EXAMPLES / "agent-registrations.example.json")
+    assert len(registrations) >= 1
+    for reg in registrations:
+        assert reg["kind"] == "AgentRegistration"
+        assert reg["apiVersion"] == "agentregistry.socioprophet.dev/v1"
+        meta = reg["metadata"]
+        assert meta.get("agentId")
+        assert meta.get("agentKind") in {"codex", "copilot", "human", "local-cli", "system"}
+        assert meta.get("version")
+        spec = reg["spec"]
+        for field in ("ownerRef", "policyProfile", "revocationState", "evidenceRef", "revocationRef"):
+            assert field in spec, f"missing {field} in AgentRegistration spec"
+
+
+def test_capability_declarations_have_required_fields() -> None:
+    declarations = load_json(WS_EXAMPLES / "capability-declarations.example.json")
+    assert len(declarations) >= 1
+    for decl in declarations:
+        assert decl["kind"] == "AgentCapabilityDeclaration"
+        spec = decl["spec"]
+        assert spec.get("allowedOperationTypes"), "allowedOperationTypes must be non-empty"
+        assert spec.get("allowedTools"), "allowedTools must be non-empty"
+        assert spec.get("allowedArtifactTypes"), "allowedArtifactTypes must be non-empty"
+        assert spec.get("policyProfile")
+        assert spec.get("evidenceRef")
+
+
+def test_operation_scopes_have_required_fields() -> None:
+    scopes = load_json(WS_EXAMPLES / "operation-scopes.example.json")
+    assert len(scopes) >= 1
+    for scope in scopes:
+        assert scope["kind"] == "AgentOperationScope"
+        spec = scope["spec"]
+        assert spec.get("allowedOperationTypes"), "allowedOperationTypes must be non-empty"
+        assert spec.get("allowedArtifactTypes"), "allowedArtifactTypes must be non-empty"
+
+
+def test_delegation_grants_are_scoped_expiring_and_have_delegated_by() -> None:
+    grants = load_json(WS_EXAMPLES / "delegation-grants.example.json")
+    assert len(grants) >= 1
+    for grant in grants:
+        assert grant["kind"] == "AgentDelegationGrant"
+        spec = grant["spec"]
+        assert spec.get("delegatedBy"), "delegatedBy required"
+        assert spec.get("expiresAt"), "expiresAt required"
+        assert spec.get("revocationState") in {"active", "revoked", "expired"}
+        assert spec.get("allowedOperationTypes"), "allowedOperationTypes must be non-empty"
+
+
+def test_tool_grants_have_evidence_required_constraint() -> None:
+    grants = load_json(WS_EXAMPLES / "tool-grants.example.json")
+    assert len(grants) >= 1
+    for grant in grants:
+        assert grant["kind"] == "AgentToolGrant"
+        spec = grant["spec"]
+        assert spec.get("allowedTools"), "allowedTools must be non-empty"
+        assert "evidence-required" in spec.get("constraints", []), "evidence-required constraint mandatory"
+        assert spec.get("expiresAt"), "expiresAt required"
+
+
+def test_budget_policies_have_budget_and_concurrency() -> None:
+    policies = load_json(WS_EXAMPLES / "budget-policies.example.json")
+    assert len(policies) >= 1
+    for policy in policies:
+        assert policy["kind"] == "AgentBudgetPolicy"
+        spec = policy["spec"]
+        budget = spec.get("defaultBudget", {})
+        assert isinstance(budget.get("maxTokensPerOperation"), int)
+        assert isinstance(budget.get("maxOperationsPerSession"), int)
+        assert isinstance(budget.get("maxArtifactsPerOperation"), int)
+        assert isinstance(spec.get("maxConcurrency"), int)
+        assert spec["maxConcurrency"] >= 1
+
+
+def test_audit_profiles_have_valid_audit_level() -> None:
+    profiles = load_json(WS_EXAMPLES / "audit-profiles.example.json")
+    assert len(profiles) >= 1
+    for profile in profiles:
+        assert profile["kind"] == "AgentAuditProfile"
+        assert profile["spec"]["auditLevel"] in {"none", "summary", "standard", "full"}
+
+
+def test_revocation_records_have_revocation_state() -> None:
+    records = load_json(WS_EXAMPLES / "revocation-records.example.json")
+    assert len(records) >= 1
+    for record in records:
+        assert record["kind"] == "AgentRevocationRecord"
+        spec = record["spec"]
+        assert spec.get("revocationState") in {"not-revoked", "revoked"}
+        assert isinstance(spec.get("revokedOperationTypes"), list)
+        assert isinstance(spec.get("revokedTools"), list)
+        assert spec.get("reasonCodes"), "reasonCodes must be non-empty"
+
+
+def test_session_bindings_reference_registered_agents() -> None:
+    registrations = load_json(WS_EXAMPLES / "agent-registrations.example.json")
+    tool_grants = load_json(WS_EXAMPLES / "tool-grants.example.json")
+    operation_scopes = load_json(WS_EXAMPLES / "operation-scopes.example.json")
+    session_bindings = load_json(WS_EXAMPLES / "session-bindings.example.json")
+
+    agent_ids = {r["metadata"]["agentId"] for r in registrations}
+    tool_grant_ids = {g["metadata"]["grantId"] for g in tool_grants}
+    scope_ids = {s["metadata"]["scopeId"] for s in operation_scopes}
+
+    for binding in session_bindings:
+        assert binding["kind"] == "AgentOperationSessionBinding"
+        spec = binding["spec"]
+        assert spec["agentId"] in agent_ids, f"unregistered agent {spec['agentId']!r}"
+        assert spec["operationScopeRef"] in scope_ids, f"unknown scope {spec['operationScopeRef']!r}"
+        for grant_ref in spec["toolGrantRefs"]:
+            assert grant_ref in tool_grant_ids, f"unknown tool grant {grant_ref!r}"
+        assert spec["status"] in {"active", "expired", "revoked"}
+
+
+def test_all_nine_workspace_operation_kinds_are_present() -> None:
+    expected_kinds = {
+        "AgentRegistration",
+        "AgentCapabilityDeclaration",
+        "AgentOperationScope",
+        "AgentDelegationGrant",
+        "AgentToolGrant",
+        "AgentBudgetPolicy",
+        "AgentAuditProfile",
+        "AgentRevocationRecord",
+        "AgentOperationSessionBinding",
+    }
+    found_kinds: set[str] = set()
+    example_files = [
+        "agent-registrations.example.json",
+        "capability-declarations.example.json",
+        "operation-scopes.example.json",
+        "delegation-grants.example.json",
+        "tool-grants.example.json",
+        "budget-policies.example.json",
+        "audit-profiles.example.json",
+        "revocation-records.example.json",
+        "session-bindings.example.json",
+    ]
+    for filename in example_files:
+        records = load_json(WS_EXAMPLES / filename)
+        for record in records:
+            found_kinds.add(record["kind"])
+    assert found_kinds == expected_kinds, f"missing kinds: {expected_kinds - found_kinds}"
+
+
+def test_revocation_records_match_registered_agents() -> None:
+    registrations = load_json(WS_EXAMPLES / "agent-registrations.example.json")
+    revocation_records = load_json(WS_EXAMPLES / "revocation-records.example.json")
+
+    revocation_ids = {r["metadata"]["revocationId"] for r in revocation_records}
+    for reg in registrations:
+        rev_ref = reg["spec"]["revocationRef"]
+        assert rev_ref in revocation_ids, f"AgentRegistration references missing revocationRef {rev_ref!r}"

--- a/tools/validate_workspace_operation_records.py
+++ b/tools/validate_workspace_operation_records.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Validate workspace-operation agent registry records.
+
+Checks all nine record kinds required for Workspace Operation Plane integration:
+  AgentRegistration, AgentCapabilityDeclaration, AgentOperationScope,
+  AgentDelegationGrant, AgentToolGrant, AgentBudgetPolicy,
+  AgentAuditProfile, AgentRevocationRecord, AgentOperationSessionBinding.
+
+Uses only the Python standard library.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+WS_EXAMPLES = ROOT / "examples" / "workspace-operations"
+
+EXAMPLES = [
+    WS_EXAMPLES / "agent-registrations.example.json",
+    WS_EXAMPLES / "capability-declarations.example.json",
+    WS_EXAMPLES / "operation-scopes.example.json",
+    WS_EXAMPLES / "delegation-grants.example.json",
+    WS_EXAMPLES / "tool-grants.example.json",
+    WS_EXAMPLES / "budget-policies.example.json",
+    WS_EXAMPLES / "audit-profiles.example.json",
+    WS_EXAMPLES / "revocation-records.example.json",
+    WS_EXAMPLES / "session-bindings.example.json",
+]
+
+ALLOWED_AGENT_KINDS = {"codex", "copilot", "human", "local-cli", "system"}
+ALLOWED_AUDIT_LEVELS = {"none", "summary", "standard", "full"}
+ALLOWED_REVOCATION_STATES = {"active", "revoked", "suspended"}
+ALLOWED_SESSION_STATUSES = {"active", "expired", "revoked"}
+
+REQUIRED_AGENT_REGISTRATION_SPEC = {"ownerRef", "policyProfile", "revocationState", "evidenceRef", "revocationRef"}
+REQUIRED_CAPABILITY_DECLARATION_SPEC = {"agentId", "allowedOperationTypes", "allowedTools", "allowedArtifactTypes", "policyProfile", "evidenceRef"}
+REQUIRED_OPERATION_SCOPE_SPEC = {"agentId", "allowedOperationTypes", "allowedArtifactTypes", "policyProfile", "evidenceRef"}
+REQUIRED_DELEGATION_GRANT_SPEC = {"agentId", "delegatedBy", "allowedOperationTypes", "allowedArtifactTypes", "policyProfile", "expiresAt", "revocationState", "evidenceRef"}
+REQUIRED_TOOL_GRANT_SPEC = {"agentId", "allowedTools", "scope", "constraints", "expiresAt", "evidenceRef"}
+REQUIRED_BUDGET_POLICY_SPEC = {"agentId", "defaultBudget", "maxConcurrency", "policyProfile", "evidenceRef"}
+REQUIRED_AUDIT_PROFILE_SPEC = {"agentId", "auditLevel", "policyProfile", "evidenceRef"}
+REQUIRED_REVOCATION_RECORD_SPEC = {"agentId", "revocationState", "revokedOperationTypes", "revokedTools", "reasonCodes", "evidenceRef"}
+REQUIRED_SESSION_BINDING_SPEC = {"agentId", "operationScopeRef", "toolGrantRefs", "budgetPolicyRef", "auditProfileRef", "status", "evidenceRef"}
+
+
+def load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def fail(msg: str) -> int:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    return 1
+
+
+def require_fields(label: str, mapping: dict, required: set[str]) -> int:
+    missing = sorted(required - set(mapping))
+    if missing:
+        return fail(f"{label}: missing fields {missing}")
+    return 0
+
+
+def record_label(path: Path, index: int | None = None) -> str:
+    rel = path.relative_to(ROOT)
+    return f"{rel}[{index}]" if index is not None else str(rel)
+
+
+def validate_record(doc: dict[str, Any], label: str) -> int:
+    if doc.get("apiVersion") != "agentregistry.socioprophet.dev/v1":
+        return fail(f"{label}: apiVersion invalid")
+    kind = doc.get("kind")
+    metadata = doc.get("metadata", {})
+    spec = doc.get("spec", {})
+
+    if kind == "AgentRegistration":
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        if metadata.get("agentKind") not in ALLOWED_AGENT_KINDS:
+            return fail(f"{label}: metadata.agentKind invalid")
+        if not metadata.get("version"):
+            return fail(f"{label}: metadata.version required")
+        rc = require_fields(label, spec, REQUIRED_AGENT_REGISTRATION_SPEC)
+        if rc:
+            return rc
+        if spec["revocationState"] not in ALLOWED_REVOCATION_STATES:
+            return fail(f"{label}: spec.revocationState invalid")
+
+    elif kind == "AgentCapabilityDeclaration":
+        if not metadata.get("declarationId"):
+            return fail(f"{label}: metadata.declarationId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        rc = require_fields(label, spec, REQUIRED_CAPABILITY_DECLARATION_SPEC)
+        if rc:
+            return rc
+        if not spec["allowedOperationTypes"]:
+            return fail(f"{label}: allowedOperationTypes must be non-empty")
+        if not spec["allowedTools"]:
+            return fail(f"{label}: allowedTools must be non-empty")
+        if not spec["allowedArtifactTypes"]:
+            return fail(f"{label}: allowedArtifactTypes must be non-empty")
+
+    elif kind == "AgentOperationScope":
+        if not metadata.get("scopeId"):
+            return fail(f"{label}: metadata.scopeId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        rc = require_fields(label, spec, REQUIRED_OPERATION_SCOPE_SPEC)
+        if rc:
+            return rc
+        if not spec["allowedOperationTypes"]:
+            return fail(f"{label}: allowedOperationTypes must be non-empty")
+        if not spec["allowedArtifactTypes"]:
+            return fail(f"{label}: allowedArtifactTypes must be non-empty")
+
+    elif kind == "AgentDelegationGrant":
+        if not metadata.get("grantId"):
+            return fail(f"{label}: metadata.grantId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        rc = require_fields(label, spec, REQUIRED_DELEGATION_GRANT_SPEC)
+        if rc:
+            return rc
+        if not spec["delegatedBy"]:
+            return fail(f"{label}: delegatedBy must be non-empty")
+        if spec["revocationState"] not in {"active", "revoked", "expired"}:
+            return fail(f"{label}: spec.revocationState invalid")
+        if not spec["allowedOperationTypes"]:
+            return fail(f"{label}: allowedOperationTypes must be non-empty")
+
+    elif kind == "AgentToolGrant":
+        if not metadata.get("grantId"):
+            return fail(f"{label}: metadata.grantId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        rc = require_fields(label, spec, REQUIRED_TOOL_GRANT_SPEC)
+        if rc:
+            return rc
+        if not spec["allowedTools"]:
+            return fail(f"{label}: allowedTools must be non-empty")
+        if not spec["constraints"]:
+            return fail(f"{label}: constraints must be non-empty")
+        if "evidence-required" not in set(spec["constraints"]):
+            return fail(f"{label}: evidence-required constraint is mandatory")
+
+    elif kind == "AgentBudgetPolicy":
+        if not metadata.get("policyId"):
+            return fail(f"{label}: metadata.policyId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        rc = require_fields(label, spec, REQUIRED_BUDGET_POLICY_SPEC)
+        if rc:
+            return rc
+        budget = spec.get("defaultBudget", {})
+        for field in ("maxTokensPerOperation", "maxOperationsPerSession", "maxArtifactsPerOperation"):
+            if not isinstance(budget.get(field), int) or budget[field] < 1:
+                return fail(f"{label}: defaultBudget.{field} must be a positive integer")
+        if not isinstance(spec.get("maxConcurrency"), int) or spec["maxConcurrency"] < 1:
+            return fail(f"{label}: maxConcurrency must be a positive integer")
+
+    elif kind == "AgentAuditProfile":
+        if not metadata.get("profileId"):
+            return fail(f"{label}: metadata.profileId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        rc = require_fields(label, spec, REQUIRED_AUDIT_PROFILE_SPEC)
+        if rc:
+            return rc
+        if spec["auditLevel"] not in ALLOWED_AUDIT_LEVELS:
+            return fail(f"{label}: auditLevel invalid")
+
+    elif kind == "AgentRevocationRecord":
+        if not metadata.get("revocationId"):
+            return fail(f"{label}: metadata.revocationId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        if not metadata.get("createdAt"):
+            return fail(f"{label}: metadata.createdAt required")
+        rc = require_fields(label, spec, REQUIRED_REVOCATION_RECORD_SPEC)
+        if rc:
+            return rc
+        if spec["revocationState"] not in {"not-revoked", "revoked"}:
+            return fail(f"{label}: revocationState invalid")
+        if not spec["reasonCodes"]:
+            return fail(f"{label}: reasonCodes must be non-empty")
+
+    elif kind == "AgentOperationSessionBinding":
+        if not metadata.get("sessionId"):
+            return fail(f"{label}: metadata.sessionId required")
+        if not metadata.get("agentId"):
+            return fail(f"{label}: metadata.agentId required")
+        if not metadata.get("createdAt"):
+            return fail(f"{label}: metadata.createdAt required")
+        rc = require_fields(label, spec, REQUIRED_SESSION_BINDING_SPEC)
+        if rc:
+            return rc
+        if spec["status"] not in ALLOWED_SESSION_STATUSES:
+            return fail(f"{label}: status invalid")
+        if not spec["toolGrantRefs"]:
+            return fail(f"{label}: toolGrantRefs must be non-empty")
+
+    else:
+        return fail(f"{label}: unknown kind {kind!r}")
+
+    return 0
+
+
+def iter_records(path: Path):
+    doc = load(path)
+    if isinstance(doc, list):
+        for index, record in enumerate(doc):
+            yield record, record_label(path, index)
+    else:
+        yield doc, record_label(path)
+
+
+def validate_cross_refs() -> int:
+    """Verify that session bindings reference registered agents, scopes, and tool grants."""
+    registrations = load(WS_EXAMPLES / "agent-registrations.example.json")
+    tool_grants = load(WS_EXAMPLES / "tool-grants.example.json")
+    operation_scopes = load(WS_EXAMPLES / "operation-scopes.example.json")
+    session_bindings = load(WS_EXAMPLES / "session-bindings.example.json")
+    revocation_records = load(WS_EXAMPLES / "revocation-records.example.json")
+
+    agent_ids = {r["metadata"]["agentId"] for r in registrations}
+    tool_grant_ids = {g["metadata"]["grantId"] for g in tool_grants}
+    scope_ids = {s["metadata"]["scopeId"] for s in operation_scopes}
+    revocation_ids = {r["metadata"]["revocationId"] for r in revocation_records}
+
+    for reg in registrations:
+        rev_ref = reg["spec"]["revocationRef"]
+        if rev_ref not in revocation_ids:
+            return fail(f"workspace-operations: AgentRegistration {reg['metadata']['agentId']} references missing revocationRef {rev_ref!r}")
+
+    for binding in session_bindings:
+        agent_id = binding["spec"]["agentId"]
+        if agent_id not in agent_ids:
+            return fail(f"workspace-operations: session binding references unregistered agent {agent_id!r}")
+        scope_ref = binding["spec"]["operationScopeRef"]
+        if scope_ref not in scope_ids:
+            return fail(f"workspace-operations: session binding references unknown scope {scope_ref!r}")
+        for grant_ref in binding["spec"]["toolGrantRefs"]:
+            if grant_ref not in tool_grant_ids:
+                return fail(f"workspace-operations: session binding references unknown tool grant {grant_ref!r}")
+
+    return 0
+
+
+def main() -> int:
+    count = 0
+    for path in EXAMPLES:
+        for record, label in iter_records(path):
+            rc = validate_record(record, label)
+            if rc:
+                return rc
+            count += 1
+
+    rc = validate_cross_refs()
+    if rc:
+        return rc
+
+    print(f"OK: validated {count} workspace-operation registry records")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean replay of #27 onto current `main`.

Original PR #27 had valid content and passed its visible workflows, but reported `mergeable: false`. This replacement branch was created from current `main` and carries forward the intended payload without forcing a stale branch merge.

## Added

- `contracts/workspace-operations/records.v0.1.schema.json`
- `docs/workspace-operations-registry.md`
- `examples/workspace-operations/*.example.json`
- `tools/validate_workspace_operation_records.py`
- `tools/tests/test_workspace_operation_records.py`

## Updated

- `Makefile`
  - adds `validate-workspace-ops`
  - wires workspace-operation registry validation into `make validate`
  - preserves existing `ops-history-grants-validate` and `validate-superconscious-reasoning-grant` targets from current main

## Validation

Original PR head `108760ee6544e25b707202d77ce31b2597eccf6b` had:

- `validate`: success
- `release-dry-run`: success

Expected commands for this replay:

```bash
make validate
make validate-workspace-ops
make test
```

## Supersedes

Supersedes #27 after this PR lands. Do not close #27 until this replay merges or another capture location is recorded.