### PR TITLE
Bind TrustOps receipt posture to agent authority decisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ validate-trustops-agent-authority-decision:
 	python3 -m json.tool contracts/trustops/agent-authority-decision.v0.1.schema.json >/dev/null
 	python3 -m json.tool contracts/trustops/agent-authority-decision.v0.1.example.json >/dev/null
 	python3 -m json.tool contracts/trustops/agent-authority-decision.pass-revoked.invalid.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-decision.missing-decision-authority.invalid.json >/dev/null
 	python3 tools/validate_trustops_agent_authority_decision.py
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -11,6 +11,12 @@ ops-history-grants-validate:
 
 validate-superconscious-reasoning-grant:
 	python3 tools/validate_superconscious_reasoning_grant.py
+
+validate-trustops-agent-authority-decision:
+	python3 -m json.tool contracts/trustops/agent-authority-decision.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-decision.v0.1.example.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-decision.pass-revoked.invalid.json >/dev/null
+	python3 tools/validate_trustops_agent_authority_decision.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/contracts/trustops/agent-authority-decision.missing-decision-authority.invalid.json
+++ b/contracts/trustops/agent-authority-decision.missing-decision-authority.invalid.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "agent-registry.trustops-agent-authority-decision.v0.1",
+  "recordType": "TrustOpsAgentAuthorityDecision",
+  "recordId": "trustops-agent-authority-decision:agent-alpha-invalid-missing-authority",
+  "agentRef": "agent-registry://agent-alpha",
+  "receiptRef": "trustops-receipt:agent-alpha-quarantine-001",
+  "receipt_outcome": "quarantine",
+  "authority_decision": "suspended",
+  "decision_actor_ref": "service://trustops-authority-evaluator-v0.1",
+  "decision_actor_kind": "service",
+  "authorization_policy_ref": "policy://trustops/agent-authority-v0.1",
+  "authorization_evidence_refs": [
+    "policy://trustops/agent-authority-v0.1",
+    "trustops-receipt:agent-alpha-quarantine-001"
+  ],
+  "effective_at": "2026-05-21T18:30:00Z",
+  "decision_timestamp": "2026-05-21T18:29:00Z",
+  "policyRefs": ["policy://trustops/agent-authority-v0.1"],
+  "gateRefs": ["gate://trustops/quarantine-suspend"],
+  "evidenceRefs": ["trustops-receipt:agent-alpha-quarantine-001"],
+  "authorityEffects": {
+    "toolAccess": "suspended",
+    "memoryAccess": "suspended",
+    "autonomousExecution": "suspended",
+    "routeEligibility": "suspended",
+    "egressMode": "blocked"
+  },
+  "restored_by_policy": {
+    "allowed": true,
+    "policyRef": "policy://trustops/agent-authority-restoration-v0.1",
+    "restoration_conditions": [
+      "fresh passing TrustOps receipt",
+      "human restoration approval"
+    ]
+  }
+}

--- a/contracts/trustops/agent-authority-decision.pass-revoked.invalid.json
+++ b/contracts/trustops/agent-authority-decision.pass-revoked.invalid.json
@@ -6,6 +6,14 @@
   "receiptRef": "trustops-receipt:agent-alpha-pass-001",
   "receipt_outcome": "pass",
   "authority_decision": "revoked",
+  "decision_actor_ref": "service://trustops-authority-evaluator-v0.1",
+  "decision_actor_kind": "service",
+  "decision_authority_ref": "authority://agent-registry/trustops-agent-authority-update",
+  "authorization_policy_ref": "policy://trustops/agent-authority-v0.1",
+  "authorization_evidence_refs": [
+    "policy://trustops/agent-authority-v0.1",
+    "trustops-receipt:agent-alpha-pass-001"
+  ],
   "effective_at": "2026-05-21T18:30:00Z",
   "decision_timestamp": "2026-05-21T18:29:00Z",
   "policyRefs": ["policy://trustops/agent-authority-v0.1"],

--- a/contracts/trustops/agent-authority-decision.pass-revoked.invalid.json
+++ b/contracts/trustops/agent-authority-decision.pass-revoked.invalid.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "agent-registry.trustops-agent-authority-decision.v0.1",
+  "recordType": "TrustOpsAgentAuthorityDecision",
+  "recordId": "trustops-agent-authority-decision:agent-alpha-invalid-pass-revoked",
+  "agentRef": "agent-registry://agent-alpha",
+  "receiptRef": "trustops-receipt:agent-alpha-pass-001",
+  "receipt_outcome": "pass",
+  "authority_decision": "revoked",
+  "effective_at": "2026-05-21T18:30:00Z",
+  "decision_timestamp": "2026-05-21T18:29:00Z",
+  "policyRefs": ["policy://trustops/agent-authority-v0.1"],
+  "gateRefs": ["gate://trustops/baseline-pass"],
+  "evidenceRefs": ["trustops-receipt:agent-alpha-pass-001"],
+  "authorityEffects": {
+    "toolAccess": "revoked",
+    "memoryAccess": "revoked",
+    "autonomousExecution": "revoked",
+    "routeEligibility": "revoked",
+    "egressMode": "blocked"
+  },
+  "restored_by_policy": {
+    "allowed": false,
+    "policyRef": "policy://trustops/no-restore"
+  }
+}

--- a/contracts/trustops/agent-authority-decision.v0.1.example.json
+++ b/contracts/trustops/agent-authority-decision.v0.1.example.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "agent-registry.trustops-agent-authority-decision.v0.1",
+  "recordType": "TrustOpsAgentAuthorityDecision",
+  "recordId": "trustops-agent-authority-decision:agent-alpha-001",
+  "agentRef": "agent-registry://agent-alpha",
+  "receiptRef": "trustops-receipt:agent-alpha-robustness-001",
+  "receipt_outcome": "require-review",
+  "authority_decision": "reduced",
+  "effective_at": "2026-05-21T18:30:00Z",
+  "decision_timestamp": "2026-05-21T18:29:00Z",
+  "policyRefs": [
+    "policy://trustops/agent-authority-v0.1"
+  ],
+  "gateRefs": [
+    "gate://trustops/high-uncertainty-human-review"
+  ],
+  "evidenceRefs": [
+    "trustops-receipt:agent-alpha-robustness-001",
+    "guardrail-action:agent-alpha-require-review-001"
+  ],
+  "authorityEffects": {
+    "toolAccess": "reduced",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "require-human-approval",
+    "routeEligibility": "reduced",
+    "egressMode": "restricted"
+  },
+  "restored_by_policy": {
+    "allowed": true,
+    "policyRef": "policy://trustops/agent-authority-restoration-v0.1",
+    "restoration_conditions": [
+      "fresh passing TrustOps receipt",
+      "human approval recorded for gated autonomous execution"
+    ]
+  },
+  "labels": {
+    "issue": "SocioProphet/agent-registry#17",
+    "guardrailIssue": "SocioProphet/guardrail-fabric#13"
+  }
+}

--- a/contracts/trustops/agent-authority-decision.v0.1.example.json
+++ b/contracts/trustops/agent-authority-decision.v0.1.example.json
@@ -6,6 +6,15 @@
   "receiptRef": "trustops-receipt:agent-alpha-robustness-001",
   "receipt_outcome": "require-review",
   "authority_decision": "reduced",
+  "decision_actor_ref": "service://trustops-authority-evaluator-v0.1",
+  "decision_actor_kind": "service",
+  "decision_authority_ref": "authority://agent-registry/trustops-agent-authority-update",
+  "authorization_policy_ref": "policy://trustops/agent-authority-v0.1",
+  "authorization_evidence_refs": [
+    "policy://trustops/agent-authority-v0.1",
+    "gate://trustops/high-uncertainty-human-review",
+    "trustops-receipt:agent-alpha-robustness-001"
+  ],
   "effective_at": "2026-05-21T18:30:00Z",
   "decision_timestamp": "2026-05-21T18:29:00Z",
   "policyRefs": [

--- a/contracts/trustops/agent-authority-decision.v0.1.schema.json
+++ b/contracts/trustops/agent-authority-decision.v0.1.schema.json
@@ -12,6 +12,11 @@
     "receiptRef",
     "receipt_outcome",
     "authority_decision",
+    "decision_actor_ref",
+    "decision_actor_kind",
+    "decision_authority_ref",
+    "authorization_policy_ref",
+    "authorization_evidence_refs",
     "effective_at",
     "decision_timestamp",
     "policyRefs",
@@ -34,6 +39,14 @@
       "type": "string",
       "enum": ["unchanged", "reduced", "suspended", "revoked"]
     },
+    "decision_actor_ref": {"type": "string"},
+    "decision_actor_kind": {
+      "type": "string",
+      "enum": ["human", "policy-engine", "service", "governance-agent"]
+    },
+    "decision_authority_ref": {"type": "string"},
+    "authorization_policy_ref": {"type": "string"},
+    "authorization_evidence_refs": {"type": "array", "items": {"type": "string"}},
     "effective_at": {"type": "string"},
     "decision_timestamp": {"type": "string"},
     "restored_by_policy": {

--- a/contracts/trustops/agent-authority-decision.v0.1.schema.json
+++ b/contracts/trustops/agent-authority-decision.v0.1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/trustops/agent-authority-decision.v0.1.schema.json",
+  "title": "TrustOps Agent Authority Decision v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "recordId",
+    "agentRef",
+    "receiptRef",
+    "receipt_outcome",
+    "authority_decision",
+    "effective_at",
+    "decision_timestamp",
+    "policyRefs",
+    "gateRefs",
+    "evidenceRefs",
+    "authorityEffects",
+    "restored_by_policy"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agent-registry.trustops-agent-authority-decision.v0.1"},
+    "recordType": {"const": "TrustOpsAgentAuthorityDecision"},
+    "recordId": {"type": "string"},
+    "agentRef": {"type": "string"},
+    "receiptRef": {"type": "string"},
+    "receipt_outcome": {
+      "type": "string",
+      "enum": ["pass", "warn", "require-review", "quarantine", "block", "rollback", "revoke"]
+    },
+    "authority_decision": {
+      "type": "string",
+      "enum": ["unchanged", "reduced", "suspended", "revoked"]
+    },
+    "effective_at": {"type": "string"},
+    "decision_timestamp": {"type": "string"},
+    "restored_by_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed", "policyRef"],
+      "properties": {
+        "allowed": {"type": "boolean"},
+        "policyRef": {"type": "string"},
+        "restoration_conditions": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "policyRefs": {"type": "array", "items": {"type": "string"}},
+    "gateRefs": {"type": "array", "items": {"type": "string"}},
+    "evidenceRefs": {"type": "array", "items": {"type": "string"}},
+    "authorityEffects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode"],
+      "properties": {
+        "toolAccess": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "memoryAccess": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "autonomousExecution": {"type": "string", "enum": ["unchanged", "require-human-approval", "suspended", "revoked"]},
+        "routeEligibility": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "egressMode": {"type": "string", "enum": ["unchanged", "restricted", "blocked"]}
+      }
+    },
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/tools/validate_trustops_agent_authority_decision.py
+++ b/tools/validate_trustops_agent_authority_decision.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Validate TrustOps agent authority decision contracts.
+
+This validator is intentionally stdlib-only. It enforces the boundary that a
+TrustOps receipt is evidence while an agent authority change is a governed
+decision with an effective time and restoration policy.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "trustops" / "agent-authority-decision.v0.1.schema.json"
+EXAMPLE = ROOT / "contracts" / "trustops" / "agent-authority-decision.v0.1.example.json"
+INVALID_PASS_REVOKED = ROOT / "contracts" / "trustops" / "agent-authority-decision.pass-revoked.invalid.json"
+
+REQUIRED_TOP_LEVEL = {
+    "schemaVersion",
+    "recordType",
+    "recordId",
+    "agentRef",
+    "receiptRef",
+    "receipt_outcome",
+    "authority_decision",
+    "effective_at",
+    "decision_timestamp",
+    "policyRefs",
+    "gateRefs",
+    "evidenceRefs",
+    "authorityEffects",
+    "restored_by_policy",
+}
+
+RECEIPT_RANK = {
+    "pass": 0,
+    "warn": 1,
+    "require-review": 2,
+    "quarantine": 3,
+    "block": 4,
+    "rollback": 5,
+    "revoke": 6,
+}
+
+AUTHORITY_RANK = {
+    "unchanged": 0,
+    "reduced": 1,
+    "suspended": 2,
+    "revoked": 3,
+}
+
+MAX_AUTHORITY_BY_RECEIPT = {
+    "pass": "unchanged",
+    "warn": "reduced",
+    "require-review": "reduced",
+    "quarantine": "suspended",
+    "block": "suspended",
+    "rollback": "suspended",
+    "revoke": "revoked",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_non_empty_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_non_empty_list(record: dict[str, Any], key: str) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{key}: expected non-empty list")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    required = set(schema.get("required", []))
+    missing = sorted(REQUIRED_TOP_LEVEL - required)
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agent-registry.trustops-agent-authority-decision.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "TrustOpsAgentAuthorityDecision":
+        fail("recordType const mismatch")
+
+
+def validate_record(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED_TOP_LEVEL - set(record))
+    if missing:
+        fail(f"missing required fields: {missing}")
+
+    if record["schemaVersion"] != "agent-registry.trustops-agent-authority-decision.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "TrustOpsAgentAuthorityDecision":
+        fail("recordType mismatch")
+
+    for key in (
+        "recordId",
+        "agentRef",
+        "receiptRef",
+        "receipt_outcome",
+        "authority_decision",
+        "effective_at",
+        "decision_timestamp",
+    ):
+        require_non_empty_string(record, key)
+
+    for key in ("policyRefs", "gateRefs", "evidenceRefs"):
+        values = require_non_empty_list(record, key)
+        for index, value in enumerate(values):
+            if not isinstance(value, str) or not value:
+                fail(f"{key}[{index}]: expected non-empty string")
+
+    receipt_outcome = record["receipt_outcome"]
+    authority_decision = record["authority_decision"]
+    if receipt_outcome not in RECEIPT_RANK:
+        fail(f"unknown receipt_outcome: {receipt_outcome}")
+    if authority_decision not in AUTHORITY_RANK:
+        fail(f"unknown authority_decision: {authority_decision}")
+
+    max_authority = MAX_AUTHORITY_BY_RECEIPT[receipt_outcome]
+    if AUTHORITY_RANK[authority_decision] > AUTHORITY_RANK[max_authority]:
+        fail(
+            "authority_decision exceeds receipt_outcome bound: "
+            f"{receipt_outcome} -> {authority_decision}"
+        )
+
+    if receipt_outcome in {"block", "rollback", "revoke"} and authority_decision == "unchanged":
+        fail(f"{receipt_outcome} cannot leave authority unchanged")
+
+    effects = record.get("authorityEffects")
+    if not isinstance(effects, dict):
+        fail("authorityEffects must be an object")
+    for key in ("toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode"):
+        require_non_empty_string(effects, key)
+
+    restored = record.get("restored_by_policy")
+    if not isinstance(restored, dict):
+        fail("restored_by_policy must be an object")
+    if not isinstance(restored.get("allowed"), bool):
+        fail("restored_by_policy.allowed must be boolean")
+    require_non_empty_string(restored, "policyRef")
+    if restored.get("allowed") is True:
+        conditions = restored.get("restoration_conditions")
+        if not isinstance(conditions, list) or not conditions:
+            fail("restored_by_policy.restoration_conditions required when restoration is allowed")
+
+
+def main() -> int:
+    try:
+        validate_schema(load_json(SCHEMA))
+        validate_record(load_json(EXAMPLE))
+        try:
+            validate_record(load_json(INVALID_PASS_REVOKED))
+        except ValidationError:
+            pass
+        else:
+            fail("invalid pass->revoked fixture unexpectedly validated")
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print("OK: TrustOps agent authority decision contract validates")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_trustops_agent_authority_decision.py
+++ b/tools/validate_trustops_agent_authority_decision.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Validate TrustOps agent authority decision contracts.
-
-This validator is intentionally stdlib-only. It enforces the boundary that a
-TrustOps receipt is evidence while an agent authority change is a governed
-decision with an effective time and restoration policy.
-"""
+"""Validate TrustOps agent authority decision contracts."""
 
 from __future__ import annotations
 
@@ -17,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "contracts" / "trustops" / "agent-authority-decision.v0.1.schema.json"
 EXAMPLE = ROOT / "contracts" / "trustops" / "agent-authority-decision.v0.1.example.json"
 INVALID_PASS_REVOKED = ROOT / "contracts" / "trustops" / "agent-authority-decision.pass-revoked.invalid.json"
+INVALID_MISSING_AUTHORITY = ROOT / "contracts" / "trustops" / "agent-authority-decision.missing-decision-authority.invalid.json"
 
 REQUIRED_TOP_LEVEL = {
     "schemaVersion",
@@ -26,6 +22,11 @@ REQUIRED_TOP_LEVEL = {
     "receiptRef",
     "receipt_outcome",
     "authority_decision",
+    "decision_actor_ref",
+    "decision_actor_kind",
+    "decision_authority_ref",
+    "authorization_policy_ref",
+    "authorization_evidence_refs",
     "effective_at",
     "decision_timestamp",
     "policyRefs",
@@ -62,6 +63,8 @@ MAX_AUTHORITY_BY_RECEIPT = {
     "revoke": "revoked",
 }
 
+DECISION_ACTOR_KINDS = {"human", "policy-engine", "service", "governance-agent"}
+
 
 class ValidationError(Exception):
     pass
@@ -94,6 +97,9 @@ def require_non_empty_list(record: dict[str, Any], key: str) -> list[Any]:
     value = record.get(key)
     if not isinstance(value, list) or not value:
         fail(f"{key}: expected non-empty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            fail(f"{key}[{index}]: expected non-empty string")
     return value
 
 
@@ -111,6 +117,9 @@ def validate_schema(schema: dict[str, Any]) -> None:
         fail("schemaVersion const mismatch")
     if props.get("recordType", {}).get("const") != "TrustOpsAgentAuthorityDecision":
         fail("recordType const mismatch")
+    actor_kind_enum = set(props.get("decision_actor_kind", {}).get("enum", []))
+    if actor_kind_enum != DECISION_ACTOR_KINDS:
+        fail("decision_actor_kind enum mismatch")
 
 
 def validate_record(record: dict[str, Any]) -> None:
@@ -129,16 +138,20 @@ def validate_record(record: dict[str, Any]) -> None:
         "receiptRef",
         "receipt_outcome",
         "authority_decision",
+        "decision_actor_ref",
+        "decision_actor_kind",
+        "decision_authority_ref",
+        "authorization_policy_ref",
         "effective_at",
         "decision_timestamp",
     ):
         require_non_empty_string(record, key)
 
+    if record["decision_actor_kind"] not in DECISION_ACTOR_KINDS:
+        fail(f"unknown decision_actor_kind: {record['decision_actor_kind']}")
+
     for key in ("policyRefs", "gateRefs", "evidenceRefs"):
-        values = require_non_empty_list(record, key)
-        for index, value in enumerate(values):
-            if not isinstance(value, str) or not value:
-                fail(f"{key}[{index}]: expected non-empty string")
+        require_non_empty_list(record, key)
 
     receipt_outcome = record["receipt_outcome"]
     authority_decision = record["authority_decision"]
@@ -156,6 +169,9 @@ def validate_record(record: dict[str, Any]) -> None:
 
     if receipt_outcome in {"block", "rollback", "revoke"} and authority_decision == "unchanged":
         fail(f"{receipt_outcome} cannot leave authority unchanged")
+
+    if authority_decision != "unchanged":
+        require_non_empty_list(record, "authorization_evidence_refs")
 
     effects = record.get("authorityEffects")
     if not isinstance(effects, dict):
@@ -175,16 +191,20 @@ def validate_record(record: dict[str, Any]) -> None:
             fail("restored_by_policy.restoration_conditions required when restoration is allowed")
 
 
+def expect_invalid(path: Path, label: str) -> None:
+    try:
+        validate_record(load_json(path))
+    except ValidationError:
+        return
+    fail(f"invalid fixture unexpectedly validated: {label}")
+
+
 def main() -> int:
     try:
         validate_schema(load_json(SCHEMA))
         validate_record(load_json(EXAMPLE))
-        try:
-            validate_record(load_json(INVALID_PASS_REVOKED))
-        except ValidationError:
-            pass
-        else:
-            fail("invalid pass->revoked fixture unexpectedly validated")
+        expect_invalid(INVALID_PASS_REVOKED, "pass-revoked")
+        expect_invalid(INVALID_MISSING_AUTHORITY, "missing-decision-authority")
     except ValidationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Implements the first authority-binding slice for #17.

This keeps the runtime boundary explicit:

- `receipt_outcome` records what TrustOps evidence said
- `authority_decision` records the governed authority effect
- `effective_at` and `decision_timestamp` remain separate
- restoration is policy-bound instead of inferred from a later passing receipt

## Adds

- `contracts/trustops/agent-authority-decision.v0.1.schema.json`
- positive authority decision fixture
- negative fixture rejecting `pass -> revoked`
- negative fixture rejecting authority change with missing decision authority
- stdlib validator: `tools/validate_trustops_agent_authority_decision.py`
- Makefile target: `validate-trustops-agent-authority-decision`

## Follow-up hardening from latest review

The authority decision now records who was allowed to make the authority change, not only what changed:

- `decision_actor_ref`
- `decision_actor_kind = human | policy-engine | service | governance-agent`
- `decision_authority_ref`
- `authorization_policy_ref`
- `authorization_evidence_refs`

The validator enforces:

- authority-changing records require non-empty authorization evidence
- `pass` cannot directly produce `revoked`
- `block`, `rollback`, and `revoke` cannot leave authority unchanged
- restoration requires explicit policy and restoration conditions when allowed

This keeps the chain useful after policy churn: the receipt records what happened, while the authority record proves who or what was authorized to issue the governed authority effect.

## Key invariants

- a receipt is evidence, not authority mutation
- a high-uncertainty receipt can reduce authority without pretending to be a hard revocation finding
- block/rollback/revoke cannot leave authority unchanged
- passing receipts cannot directly revoke authority
- authority changes require explicit authorization provenance
- restoration requires explicit policy and restoration conditions when allowed

## Validation

Expected local gate:

```bash
make validate-trustops-agent-authority-decision
```

## Issue

Advances #17 and consumes the guardrail action boundary from SocioProphet/guardrail-fabric#13.