### PR TITLE
Add TrustOps authority current-state contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -18,6 +18,18 @@ validate-trustops-agent-authority-decision:
 	python3 -m json.tool contracts/trustops/agent-authority-decision.pass-revoked.invalid.json >/dev/null
 	python3 -m json.tool contracts/trustops/agent-authority-decision.missing-decision-authority.invalid.json >/dev/null
 	python3 tools/validate_trustops_agent_authority_decision.py
+
+validate-authority-state-contracts:
+	python3 -m json.tool contracts/trustops/agent-authority-current-state.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/trustops/authority-restoration-decision.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-current-state.active.example.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-current-state.reduced.example.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-current-state.suspended.example.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-current-state.revoked.example.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-current-state.raw-receipt.invalid.json >/dev/null
+	python3 -m json.tool contracts/trustops/authority-restoration-decision.restore.example.json >/dev/null
+	python3 -m json.tool contracts/trustops/authority-restoration-decision.missing-authorization.invalid.json >/dev/null
+	python3 tools/validate_authority_state_contracts.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/contracts/trustops/agent-authority-current-state.active.example.json
+++ b/contracts/trustops/agent-authority-current-state.active.example.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:active",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:30:00Z",
+  "authority_status": "active",
+  "effective_decision_ref": "trustops-agent-authority-decision:agent-alpha-pass-001",
+  "source_decision_refs": [
+    "trustops-agent-authority-decision:agent-alpha-pass-001"
+  ],
+  "evidenceRefs": [
+    "trustops-receipt:agent-alpha-pass-001",
+    "policy://trustops/agent-authority-v0.1"
+  ],
+  "authorityEffects": {
+    "toolAccess": "unchanged",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "unchanged",
+    "routeEligibility": "unchanged",
+    "egressMode": "unchanged"
+  },
+  "restoration_required": false,
+  "receipt_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "labels": {
+    "fixture": "active"
+  }
+}

--- a/contracts/trustops/agent-authority-current-state.raw-receipt.invalid.json
+++ b/contracts/trustops/agent-authority-current-state.raw-receipt.invalid.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:invalid-raw-receipt",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:34:00Z",
+  "authority_status": "suspended",
+  "effective_decision_ref": "trustops-receipt:agent-alpha-quarantine-001",
+  "source_decision_refs": [
+    "trustops-receipt:agent-alpha-quarantine-001"
+  ],
+  "evidenceRefs": [
+    "trustops-receipt:agent-alpha-quarantine-001"
+  ],
+  "authorityEffects": {
+    "toolAccess": "suspended",
+    "memoryAccess": "suspended",
+    "autonomousExecution": "suspended",
+    "routeEligibility": "suspended",
+    "egressMode": "blocked"
+  },
+  "restoration_required": true,
+  "restoration_policy_ref": "policy://trustops/agent-authority-restoration-v0.1",
+  "restoration_conditions": [
+    "fresh passing TrustOps receipt",
+    "explicit restoration decision"
+  ],
+  "receipt_hash": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+}

--- a/contracts/trustops/agent-authority-current-state.reduced.example.json
+++ b/contracts/trustops/agent-authority-current-state.reduced.example.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:reduced",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:32:00Z",
+  "authority_status": "reduced",
+  "effective_decision_ref": "trustops-agent-authority-decision:agent-alpha-review-001",
+  "source_decision_refs": [
+    "trustops-agent-authority-decision:agent-alpha-review-001"
+  ],
+  "evidenceRefs": [
+    "trustops-receipt:agent-alpha-review-001",
+    "guardrail-action:agent-alpha-require-review-001",
+    "policy://trustops/agent-authority-v0.1"
+  ],
+  "authorityEffects": {
+    "toolAccess": "reduced",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "require-human-approval",
+    "routeEligibility": "reduced",
+    "egressMode": "restricted"
+  },
+  "restoration_required": false,
+  "receipt_hash": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+  "labels": {
+    "fixture": "reduced"
+  }
+}

--- a/contracts/trustops/agent-authority-current-state.revoked.example.json
+++ b/contracts/trustops/agent-authority-current-state.revoked.example.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:revoked",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:33:00Z",
+  "authority_status": "revoked",
+  "effective_decision_ref": "trustops-agent-authority-decision:agent-alpha-revoke-001",
+  "source_decision_refs": [
+    "trustops-agent-authority-decision:agent-alpha-revoke-001"
+  ],
+  "evidenceRefs": [
+    "trustops-receipt:agent-alpha-revoke-001",
+    "guardrail-action:agent-alpha-revoke-001",
+    "policy://trustops/agent-authority-v0.1"
+  ],
+  "authorityEffects": {
+    "toolAccess": "revoked",
+    "memoryAccess": "revoked",
+    "autonomousExecution": "revoked",
+    "routeEligibility": "revoked",
+    "egressMode": "blocked"
+  },
+  "restoration_required": true,
+  "restoration_policy_ref": "policy://trustops/agent-authority-restoration-v0.1",
+  "restoration_conditions": [
+    "new authority grant",
+    "fresh passing TrustOps receipt",
+    "human restoration approval",
+    "authorization evidence recorded"
+  ],
+  "receipt_hash": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+  "labels": {
+    "fixture": "revoked"
+  }
+}

--- a/contracts/trustops/agent-authority-current-state.suspended.example.json
+++ b/contracts/trustops/agent-authority-current-state.suspended.example.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "agent-registry.agent-authority-current-state.v0.1",
+  "recordType": "AgentAuthorityCurrentState",
+  "stateId": "agent-authority-current-state:agent-alpha:suspended",
+  "agentRef": "agent-registry://agent-alpha",
+  "computed_at": "2026-05-22T12:31:00Z",
+  "authority_status": "suspended",
+  "effective_decision_ref": "trustops-agent-authority-decision:agent-alpha-quarantine-001",
+  "source_decision_refs": [
+    "trustops-agent-authority-decision:agent-alpha-quarantine-001"
+  ],
+  "evidenceRefs": [
+    "trustops-receipt:agent-alpha-quarantine-001",
+    "guardrail-action:agent-alpha-quarantine-001",
+    "policy://trustops/agent-authority-v0.1"
+  ],
+  "authorityEffects": {
+    "toolAccess": "suspended",
+    "memoryAccess": "suspended",
+    "autonomousExecution": "suspended",
+    "routeEligibility": "suspended",
+    "egressMode": "blocked"
+  },
+  "restoration_required": true,
+  "restoration_policy_ref": "policy://trustops/agent-authority-restoration-v0.1",
+  "restoration_conditions": [
+    "fresh passing TrustOps receipt",
+    "explicit restoration decision",
+    "authorization evidence recorded"
+  ],
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+  "labels": {
+    "fixture": "suspended"
+  }
+}

--- a/contracts/trustops/agent-authority-current-state.v0.1.schema.json
+++ b/contracts/trustops/agent-authority-current-state.v0.1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/trustops/agent-authority-current-state.v0.1.schema.json",
+  "title": "Agent Authority Current State v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "stateId",
+    "agentRef",
+    "computed_at",
+    "authority_status",
+    "effective_decision_ref",
+    "source_decision_refs",
+    "evidenceRefs",
+    "authorityEffects",
+    "restoration_required",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agent-registry.agent-authority-current-state.v0.1"},
+    "recordType": {"const": "AgentAuthorityCurrentState"},
+    "stateId": {"type": "string"},
+    "agentRef": {"type": "string"},
+    "computed_at": {"type": "string"},
+    "authority_status": {"type": "string", "enum": ["active", "reduced", "suspended", "revoked"]},
+    "effective_decision_ref": {"type": "string"},
+    "source_decision_refs": {"type": "array", "items": {"type": "string"}},
+    "evidenceRefs": {"type": "array", "items": {"type": "string"}},
+    "authorityEffects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode"],
+      "properties": {
+        "toolAccess": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "memoryAccess": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "autonomousExecution": {"type": "string", "enum": ["unchanged", "require-human-approval", "suspended", "revoked"]},
+        "routeEligibility": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "egressMode": {"type": "string", "enum": ["unchanged", "restricted", "blocked"]}
+      }
+    },
+    "restoration_required": {"type": "boolean"},
+    "restoration_policy_ref": {"type": "string"},
+    "restoration_conditions": {"type": "array", "items": {"type": "string"}},
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/contracts/trustops/authority-restoration-decision.missing-authorization.invalid.json
+++ b/contracts/trustops/authority-restoration-decision.missing-authorization.invalid.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "agent-registry.authority-restoration-decision.v0.1",
+  "recordType": "AuthorityRestorationDecision",
+  "restorationId": "authority-restoration-decision:agent-alpha:invalid-missing-authz",
+  "agentRef": "agent-registry://agent-alpha",
+  "prior_state_ref": "agent-authority-current-state:agent-alpha:suspended",
+  "restoration_decision": "restore",
+  "decision_actor_ref": "human://reviewer/trustops-reviewer-001",
+  "decision_actor_kind": "human",
+  "authorization_policy_ref": "policy://trustops/agent-authority-restoration-v0.1",
+  "authorization_evidence_refs": [],
+  "restored_authority_status": "active",
+  "restored_effects": {
+    "toolAccess": "unchanged",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "unchanged",
+    "routeEligibility": "unchanged",
+    "egressMode": "unchanged"
+  },
+  "effective_at": "2026-05-22T12:35:00Z",
+  "decision_timestamp": "2026-05-22T12:34:30Z",
+  "reason": "Invalid restoration because authorization evidence is missing.",
+  "receipt_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+}

--- a/contracts/trustops/authority-restoration-decision.restore.example.json
+++ b/contracts/trustops/authority-restoration-decision.restore.example.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "agent-registry.authority-restoration-decision.v0.1",
+  "recordType": "AuthorityRestorationDecision",
+  "restorationId": "authority-restoration-decision:agent-alpha:restore-001",
+  "agentRef": "agent-registry://agent-alpha",
+  "prior_state_ref": "agent-authority-current-state:agent-alpha:suspended",
+  "restoration_decision": "restore",
+  "decision_actor_ref": "human://reviewer/trustops-reviewer-001",
+  "decision_actor_kind": "human",
+  "authorization_policy_ref": "policy://trustops/agent-authority-restoration-v0.1",
+  "authorization_evidence_refs": [
+    "trustops-receipt:agent-alpha-pass-002",
+    "human-review:agent-alpha-restore-001",
+    "policy://trustops/agent-authority-restoration-v0.1"
+  ],
+  "restored_authority_status": "active",
+  "restored_effects": {
+    "toolAccess": "unchanged",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "unchanged",
+    "routeEligibility": "unchanged",
+    "egressMode": "unchanged"
+  },
+  "effective_at": "2026-05-22T12:35:00Z",
+  "decision_timestamp": "2026-05-22T12:34:30Z",
+  "reason": "Restoration authorized after fresh passing receipt and human review.",
+  "receipt_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+  "labels": {
+    "fixture": "restore"
+  }
+}

--- a/contracts/trustops/authority-restoration-decision.v0.1.schema.json
+++ b/contracts/trustops/authority-restoration-decision.v0.1.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/trustops/authority-restoration-decision.v0.1.schema.json",
+  "title": "Authority Restoration Decision v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "restorationId",
+    "agentRef",
+    "prior_state_ref",
+    "restoration_decision",
+    "decision_actor_ref",
+    "decision_actor_kind",
+    "authorization_policy_ref",
+    "authorization_evidence_refs",
+    "restored_authority_status",
+    "restored_effects",
+    "effective_at",
+    "decision_timestamp",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agent-registry.authority-restoration-decision.v0.1"},
+    "recordType": {"const": "AuthorityRestorationDecision"},
+    "restorationId": {"type": "string"},
+    "agentRef": {"type": "string"},
+    "prior_state_ref": {"type": "string"},
+    "restoration_decision": {"type": "string", "enum": ["restore", "deny", "require-review"]},
+    "decision_actor_ref": {"type": "string"},
+    "decision_actor_kind": {"type": "string", "enum": ["human", "policy-engine", "service", "governance-agent"]},
+    "authorization_policy_ref": {"type": "string"},
+    "authorization_evidence_refs": {"type": "array", "items": {"type": "string"}},
+    "restored_authority_status": {"type": "string", "enum": ["active", "reduced", "suspended", "revoked"]},
+    "restored_effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode"],
+      "properties": {
+        "toolAccess": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "memoryAccess": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "autonomousExecution": {"type": "string", "enum": ["unchanged", "require-human-approval", "suspended", "revoked"]},
+        "routeEligibility": {"type": "string", "enum": ["unchanged", "reduced", "suspended", "revoked"]},
+        "egressMode": {"type": "string", "enum": ["unchanged", "restricted", "blocked"]}
+      }
+    },
+    "effective_at": {"type": "string"},
+    "decision_timestamp": {"type": "string"},
+    "reason": {"type": "string"},
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/docs/trustops-authority-current-state.md
+++ b/docs/trustops-authority-current-state.md
@@ -1,0 +1,87 @@
+# TrustOps Agent Authority Current State v0.1
+
+## Purpose
+
+`AgentAuthorityCurrentState` records the current runtime authority posture for an agent.
+
+It is derived from explicit authority decisions and restoration decisions. It is not inferred directly from raw TrustOps receipts.
+
+This closes the control-plane gap between receipt evidence and runtime authority state.
+
+## Boundary
+
+Agent Registry owns:
+
+- current authority state
+- authority restoration decisions
+- authority effect summaries
+- restoration requirements
+
+Guardrail Fabric owns TrustOps runtime action mapping.
+
+AgentPlane consumes current authority state during attempt admission.
+
+## Current state
+
+The current-state record includes:
+
+- `agentRef`
+- `authority_status = active | reduced | suspended | revoked`
+- `effective_decision_ref`
+- `source_decision_refs`
+- `evidenceRefs`
+- `authorityEffects`
+- `restoration_required`
+- optional restoration policy and conditions
+
+## Derivation rule
+
+Current authority state must derive from one of:
+
+- `trustops-agent-authority-decision:*`
+- `authority-restoration-decision:*`
+
+It must not derive directly from:
+
+- `trustops-receipt:*`
+
+Raw receipts are evidence. They are not authority mutations.
+
+## Restoration
+
+`AuthorityRestorationDecision` records explicit restoration or denial.
+
+A passing TrustOps receipt does not automatically restore authority.
+
+Restoration requires:
+
+- a prior state ref
+- a restoration decision
+- an authorized decision actor
+- authorization policy
+- authorization evidence
+- restored authority effects
+- effective timestamp
+
+## Validation
+
+```bash
+make validate-authority-state-contracts
+```
+
+The validator checks:
+
+- active/reduced/suspended/revoked current-state fixtures
+- restoration decision fixture
+- missing restoration authorization negative fixture
+- raw-receipt-derived current-state negative fixture
+
+## Non-goals
+
+This contract does not execute agent work.
+
+It does not run safety preflight.
+
+It does not emit AgentPlane attempt admissions.
+
+It gives AgentPlane one authoritative authority-state input for admission decisions.

--- a/tools/validate_authority_state_contracts.py
+++ b/tools/validate_authority_state_contracts.py
@@ -6,13 +6,16 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 ROOT = Path(__file__).resolve().parents[1]
 STATE_SCHEMA = ROOT / "contracts" / "trustops" / "agent-authority-current-state.v0.1.schema.json"
 RESTORE_SCHEMA = ROOT / "contracts" / "trustops" / "authority-restoration-decision.v0.1.schema.json"
 ACTIVE = ROOT / "contracts" / "trustops" / "agent-authority-current-state.active.example.json"
+REDUCED = ROOT / "contracts" / "trustops" / "agent-authority-current-state.reduced.example.json"
 SUSPENDED = ROOT / "contracts" / "trustops" / "agent-authority-current-state.suspended.example.json"
+REVOKED = ROOT / "contracts" / "trustops" / "agent-authority-current-state.revoked.example.json"
+RAW_RECEIPT_INVALID = ROOT / "contracts" / "trustops" / "agent-authority-current-state.raw-receipt.invalid.json"
 RESTORE = ROOT / "contracts" / "trustops" / "authority-restoration-decision.restore.example.json"
 INVALID_RESTORE = ROOT / "contracts" / "trustops" / "authority-restoration-decision.missing-authorization.invalid.json"
 
@@ -115,6 +118,16 @@ def validate_effects(value: Any, label: str) -> None:
         require_string(value, key)
 
 
+def require_authority_decision_ref(value: str, label: str) -> None:
+    if value.startswith("trustops-receipt:"):
+        fail(f"{label} must reference an authority decision, not a raw TrustOps receipt")
+    if not (
+        value.startswith("trustops-agent-authority-decision:")
+        or value.startswith("authority-restoration-decision:")
+    ):
+        fail(f"{label} must reference an authority decision or restoration decision")
+
+
 def validate_state(record: dict[str, Any]) -> None:
     missing = sorted(STATE_REQUIRED - set(record))
     if missing:
@@ -127,7 +140,10 @@ def validate_state(record: dict[str, Any]) -> None:
         require_string(record, key)
     if record["authority_status"] not in STATUS:
         fail(f"unknown authority_status: {record['authority_status']}")
-    require_list(record, "source_decision_refs")
+    require_authority_decision_ref(record["effective_decision_ref"], "effective_decision_ref")
+    source_refs = require_list(record, "source_decision_refs")
+    for index, source_ref in enumerate(source_refs):
+        require_authority_decision_ref(source_ref, f"source_decision_refs[{index}]")
     require_list(record, "evidenceRefs")
     validate_effects(record.get("authorityEffects"), "authorityEffects")
     if not isinstance(record.get("restoration_required"), bool):
@@ -181,7 +197,7 @@ def validate_restoration(record: dict[str, Any]) -> None:
         fail("non-restore decisions cannot restore active authority")
 
 
-def expect_invalid(path: Path, validator, label: str) -> None:
+def expect_invalid(path: Path, validator: Callable[[dict[str, Any]], None], label: str) -> None:
     try:
         validator(load_json(path))
     except ValidationError:
@@ -193,10 +209,11 @@ def main() -> int:
     try:
         validate_schema(load_json(STATE_SCHEMA), STATE_REQUIRED, "state")
         validate_schema(load_json(RESTORE_SCHEMA), RESTORE_REQUIRED, "restoration")
-        validate_state(load_json(ACTIVE))
-        validate_state(load_json(SUSPENDED))
+        for fixture in (ACTIVE, REDUCED, SUSPENDED, REVOKED):
+            validate_state(load_json(fixture))
         validate_restoration(load_json(RESTORE))
         expect_invalid(INVALID_RESTORE, validate_restoration, "missing restoration authorization")
+        expect_invalid(RAW_RECEIPT_INVALID, validate_state, "raw receipt derived state")
     except ValidationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/tools/validate_authority_state_contracts.py
+++ b/tools/validate_authority_state_contracts.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Validate authority current-state and restoration contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+STATE_SCHEMA = ROOT / "contracts" / "trustops" / "agent-authority-current-state.v0.1.schema.json"
+RESTORE_SCHEMA = ROOT / "contracts" / "trustops" / "authority-restoration-decision.v0.1.schema.json"
+ACTIVE = ROOT / "contracts" / "trustops" / "agent-authority-current-state.active.example.json"
+SUSPENDED = ROOT / "contracts" / "trustops" / "agent-authority-current-state.suspended.example.json"
+RESTORE = ROOT / "contracts" / "trustops" / "authority-restoration-decision.restore.example.json"
+INVALID_RESTORE = ROOT / "contracts" / "trustops" / "authority-restoration-decision.missing-authorization.invalid.json"
+
+STATE_REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "stateId",
+    "agentRef",
+    "computed_at",
+    "authority_status",
+    "effective_decision_ref",
+    "source_decision_refs",
+    "evidenceRefs",
+    "authorityEffects",
+    "restoration_required",
+    "receipt_hash",
+}
+
+RESTORE_REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "restorationId",
+    "agentRef",
+    "prior_state_ref",
+    "restoration_decision",
+    "decision_actor_ref",
+    "decision_actor_kind",
+    "authorization_policy_ref",
+    "authorization_evidence_refs",
+    "restored_authority_status",
+    "restored_effects",
+    "effective_at",
+    "decision_timestamp",
+    "receipt_hash",
+}
+
+STATUS = {"active", "reduced", "suspended", "revoked"}
+RESTORE_DECISIONS = {"restore", "deny", "require-review"}
+ACTOR_KINDS = {"human", "policy-engine", "service", "governance-agent"}
+EFFECT_FIELDS = ("toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode")
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{key}: expected non-empty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            fail(f"{key}[{index}]: expected non-empty string")
+    return value
+
+
+def require_hash(record: dict[str, Any], key: str) -> None:
+    value = require_string(record, key)
+    if not value.startswith("sha256:"):
+        fail(f"{key} must be sha256-bound")
+
+
+def validate_schema(schema: dict[str, Any], required: set[str], label: str) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail(f"{label} schema must use JSON Schema draft 2020-12")
+    if schema.get("additionalProperties") is not False:
+        fail(f"{label} schema must be strict")
+    missing = sorted(required - set(schema.get("required", [])))
+    if missing:
+        fail(f"{label} schema missing required fields: {missing}")
+
+
+def validate_effects(value: Any, label: str) -> None:
+    if not isinstance(value, dict):
+        fail(f"{label} must be an object")
+    for key in EFFECT_FIELDS:
+        require_string(value, key)
+
+
+def validate_state(record: dict[str, Any]) -> None:
+    missing = sorted(STATE_REQUIRED - set(record))
+    if missing:
+        fail(f"authority current state missing required fields: {missing}")
+    if record["schemaVersion"] != "agent-registry.agent-authority-current-state.v0.1":
+        fail("state schemaVersion mismatch")
+    if record["recordType"] != "AgentAuthorityCurrentState":
+        fail("state recordType mismatch")
+    for key in ("stateId", "agentRef", "computed_at", "authority_status", "effective_decision_ref"):
+        require_string(record, key)
+    if record["authority_status"] not in STATUS:
+        fail(f"unknown authority_status: {record['authority_status']}")
+    require_list(record, "source_decision_refs")
+    require_list(record, "evidenceRefs")
+    validate_effects(record.get("authorityEffects"), "authorityEffects")
+    if not isinstance(record.get("restoration_required"), bool):
+        fail("restoration_required must be boolean")
+    require_hash(record, "receipt_hash")
+
+    if record["authority_status"] in {"suspended", "revoked"}:
+        if record.get("restoration_required") is not True:
+            fail("suspended/revoked states require restoration_required=true")
+        require_string(record, "restoration_policy_ref")
+        require_list(record, "restoration_conditions")
+
+    if record["authority_status"] == "active" and record.get("restoration_required") is not False:
+        fail("active state must not require restoration")
+
+
+def validate_restoration(record: dict[str, Any]) -> None:
+    missing = sorted(RESTORE_REQUIRED - set(record))
+    if missing:
+        fail(f"authority restoration decision missing required fields: {missing}")
+    if record["schemaVersion"] != "agent-registry.authority-restoration-decision.v0.1":
+        fail("restoration schemaVersion mismatch")
+    if record["recordType"] != "AuthorityRestorationDecision":
+        fail("restoration recordType mismatch")
+    for key in (
+        "restorationId",
+        "agentRef",
+        "prior_state_ref",
+        "restoration_decision",
+        "decision_actor_ref",
+        "decision_actor_kind",
+        "authorization_policy_ref",
+        "restored_authority_status",
+        "effective_at",
+        "decision_timestamp",
+    ):
+        require_string(record, key)
+    if record["restoration_decision"] not in RESTORE_DECISIONS:
+        fail(f"unknown restoration_decision: {record['restoration_decision']}")
+    if record["decision_actor_kind"] not in ACTOR_KINDS:
+        fail(f"unknown decision_actor_kind: {record['decision_actor_kind']}")
+    if record["restored_authority_status"] not in STATUS:
+        fail(f"unknown restored_authority_status: {record['restored_authority_status']}")
+    require_list(record, "authorization_evidence_refs")
+    validate_effects(record.get("restored_effects"), "restored_effects")
+    require_hash(record, "receipt_hash")
+
+    if record["restoration_decision"] == "restore" and record["restored_authority_status"] not in {"active", "reduced"}:
+        fail("restore decision must restore to active or reduced")
+    if record["restoration_decision"] != "restore" and record["restored_authority_status"] == "active":
+        fail("non-restore decisions cannot restore active authority")
+
+
+def expect_invalid(path: Path, validator, label: str) -> None:
+    try:
+        validator(load_json(path))
+    except ValidationError:
+        return
+    fail(f"invalid fixture unexpectedly validated: {label}")
+
+
+def main() -> int:
+    try:
+        validate_schema(load_json(STATE_SCHEMA), STATE_REQUIRED, "state")
+        validate_schema(load_json(RESTORE_SCHEMA), RESTORE_REQUIRED, "restoration")
+        validate_state(load_json(ACTIVE))
+        validate_state(load_json(SUSPENDED))
+        validate_restoration(load_json(RESTORE))
+        expect_invalid(INVALID_RESTORE, validate_restoration, "missing restoration authorization")
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print("OK: authority state contracts validate")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `AgentAuthorityCurrentState v0.1` and `AuthorityRestorationDecision v0.1` so AgentPlane can consume an authoritative current authority state during attempt admission.

This closes the gap between TrustOps receipt evidence and runtime authority posture: raw receipts remain evidence, while current authority state derives only from explicit authority decisions or restoration decisions.

## Adds

- `contracts/trustops/agent-authority-current-state.v0.1.schema.json`
- `contracts/trustops/authority-restoration-decision.v0.1.schema.json`
- current-state fixtures for:
  - active
  - reduced
  - suspended
  - revoked
- restoration decision fixture
- negative fixtures for:
  - restoration missing authorization evidence
  - current state derived directly from a raw TrustOps receipt
- `tools/validate_authority_state_contracts.py`
- `docs/trustops-authority-current-state.md`
- Makefile target: `validate-authority-state-contracts`

## Key invariants

- current authority state is derived from `trustops-agent-authority-decision:*` or `authority-restoration-decision:*`
- current authority state cannot derive directly from `trustops-receipt:*`
- suspended/revoked states require restoration policy and restoration conditions
- active states must not require restoration
- restoration requires explicit authorization evidence
- passing receipts do not automatically restore authority

## Validation

```bash
make validate-authority-state-contracts
```

## Notes

This is the authority-state input needed before AgentPlane admission orchestration can issue a fully grounded `AttemptAdmissionReceipt`. It does not execute agent work, run preflight, or mutate authority by itself.