### PR TITLE
Add Workspace Context authority binding v0.1

### DIFF
--- a/.github/workflows/workspace-context-authority-binding.yml
+++ b/.github/workflows/workspace-context-authority-binding.yml
@@ -1,0 +1,31 @@
+name: workspace-context-authority-binding
+
+on:
+  pull_request:
+    paths:
+      - "docs/workspace-context-authority-binding.md"
+      - "contracts/workspace-context/**"
+      - "tools/validate_workspace_context_authority_binding.py"
+      - ".github/workflows/workspace-context-authority-binding.yml"
+      - "Makefile"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/workspace-context-authority-binding.md"
+      - "contracts/workspace-context/**"
+      - "tools/validate_workspace_context_authority_binding.py"
+      - ".github/workflows/workspace-context-authority-binding.yml"
+      - "Makefile"
+  workflow_dispatch:
+
+jobs:
+  validate-workspace-context-authority-binding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate Workspace Context authority binding
+        run: make validate-workspace-context-authority-binding

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-workspace-context-authority-binding
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-workspace-context-authority-binding
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -30,6 +30,11 @@ validate-authority-state-contracts:
 	python3 -m json.tool contracts/trustops/authority-restoration-decision.restore.example.json >/dev/null
 	python3 -m json.tool contracts/trustops/authority-restoration-decision.missing-authorization.invalid.json >/dev/null
 	python3 tools/validate_authority_state_contracts.py
+
+validate-workspace-context-authority-binding:
+	python3 -m json.tool contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json >/dev/null
+	python3 tools/validate_workspace_context_authority_binding.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json
+++ b/contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "agent-registry.workspace-context-authority-binding.v0.1",
+  "recordType": "WorkspaceContextAuthorityBinding",
+  "bindingId": "workspace-context-authority-binding-demo-0001",
+  "createdAt": "2026-05-22T17:05:00Z",
+  "workroomRef": "workroom://workroom-demo-0001",
+  "professionalWorkroomRef": "professional-workroom://workroom-demo-0001",
+  "contextGraphRef": "ctxgraph-demo-0001",
+  "runtimeBindingRef": "runtime-binding-demo-0001",
+  "agentRefs": [
+    "agent-registry://agents/context-fabric-reviewer"
+  ],
+  "sessionRefs": [
+    "urn:srcos:session:context-fabric-demo-0001"
+  ],
+  "authorityStateRefs": [
+    "agent-authority-current-state:context-fabric-reviewer:active"
+  ],
+  "grantRefs": [
+    "agent-registry://grants/context-fabric-demo-0001"
+  ],
+  "revocationRefs": [],
+  "policyRefs": [
+    "policy-decision://policy-demo-ai-use/decision-0001"
+  ],
+  "evidenceRefs": [
+    "agentplane://evidence/workroom-context-demo-0001",
+    "platform://workspace-context-record-demo-0001"
+  ],
+  "status": "active",
+  "labels": {
+    "surface": "workspace-context",
+    "fixture": "public-synthetic"
+  }
+}

--- a/contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json
+++ b/contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/workspace-context/workspace-context-authority-binding.v0.1.schema.json",
+  "title": "WorkspaceContextAuthorityBinding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "bindingId",
+    "createdAt",
+    "workroomRef",
+    "contextGraphRef",
+    "runtimeBindingRef",
+    "agentRefs",
+    "sessionRefs",
+    "authorityStateRefs",
+    "grantRefs",
+    "policyRefs",
+    "evidenceRefs",
+    "status"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "agent-registry.workspace-context-authority-binding.v0.1" },
+    "recordType": { "const": "WorkspaceContextAuthorityBinding" },
+    "bindingId": { "type": "string" },
+    "createdAt": { "type": "string" },
+    "workroomRef": { "type": "string" },
+    "professionalWorkroomRef": { "type": ["string", "null"] },
+    "contextGraphRef": { "type": "string" },
+    "runtimeBindingRef": { "type": "string" },
+    "agentRefs": { "type": "array", "items": { "type": "string" } },
+    "sessionRefs": { "type": "array", "items": { "type": "string" } },
+    "authorityStateRefs": { "type": "array", "items": { "type": "string" } },
+    "grantRefs": { "type": "array", "items": { "type": "string" } },
+    "revocationRefs": { "type": "array", "items": { "type": "string" } },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "status": { "type": "string", "enum": ["active", "reduced", "suspended", "revoked", "review"] },
+    "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+  }
+}

--- a/docs/workspace-context-authority-binding.md
+++ b/docs/workspace-context-authority-binding.md
@@ -1,0 +1,39 @@
+# Workspace Context Authority Binding
+
+## Purpose
+
+This document defines the Agent Registry binding for Prophet Workspace Context Fabric.
+
+Prophet Workspace owns the Workroom and Context Fabric domain contracts. Agent Registry owns agent identity, sessions, authority state, grants, and revocation references consumed by those workspace contracts.
+
+## Object
+
+The first binding object is:
+
+```text
+contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json
+contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json
+```
+
+## Boundary
+
+Agent Registry does not store workspace context graphs. It records the authority references needed for a workroom runtime binding to be admitted and audited.
+
+The binding includes:
+
+- workroom ref;
+- context graph ref;
+- runtime binding ref;
+- agent refs;
+- session refs;
+- authority current-state refs;
+- grant refs;
+- revocation refs;
+- evidence refs;
+- policy refs.
+
+## Validation
+
+```bash
+make validate-workspace-context-authority-binding
+```

--- a/tools/validate_workspace_context_authority_binding.py
+++ b/tools/validate_workspace_context_authority_binding.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Validate WorkspaceContextAuthorityBinding example."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json"
+EXAMPLE = ROOT / "contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json"
+
+
+def main():
+    try:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        for key in schema["required"]:
+            if key not in example:
+                raise AssertionError(f"missing {key}")
+        assert example["schemaVersion"] == "agent-registry.workspace-context-authority-binding.v0.1"
+        assert example["recordType"] == "WorkspaceContextAuthorityBinding"
+        assert example["workroomRef"].startswith("workroom://")
+        assert example["contextGraphRef"]
+        assert example["runtimeBindingRef"]
+        assert example["agentRefs"]
+        assert example["sessionRefs"]
+        assert example["authorityStateRefs"]
+        assert example["grantRefs"]
+        assert example["policyRefs"]
+        assert example["evidenceRefs"]
+    except Exception as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: WorkspaceContextAuthorityBinding validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the Agent Registry authority-side binding for Prophet Workspace Context Fabric.

`prophet-workspace` owns Workroom and Context Fabric semantics. This PR gives Agent Registry a `WorkspaceContextAuthorityBinding` record that supplies explicit agent/session/authority-state/grant/revocation refs consumed by WorkspaceContextRuntimeBinding.

## Changes

- Add `docs/workspace-context-authority-binding.md`
- Add `contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json`
- Add `contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json`
- Add `tools/validate_workspace_context_authority_binding.py`
- Add `make validate-workspace-context-authority-binding`
- Add `.github/workflows/workspace-context-authority-binding.yml`

## Boundary posture

- Agent Registry does not store workspace context graphs.
- Agent Registry owns the authority refs used by workroom runtime bindings.
- AgentPlane remains execution evidence authority.
- Memory Mesh remains recall/context-pack authority.
- Prophet Platform remains runtime/evidence record authority.

## Validation

```bash
make validate-workspace-context-authority-binding
```
