### PR TITLE
Add read-only authority-state lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -30,6 +30,11 @@ validate-authority-state-contracts:
 	python3 -m json.tool contracts/trustops/authority-restoration-decision.restore.example.json >/dev/null
 	python3 -m json.tool contracts/trustops/authority-restoration-decision.missing-authorization.invalid.json >/dev/null
 	python3 tools/validate_authority_state_contracts.py
+
+validate-authority-state-lookup:
+	python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --status active >/tmp/agent-registry-authority-active.json
+	python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --state-file contracts/trustops/agent-authority-current-state.suspended.example.json >/tmp/agent-registry-authority-suspended.json
+	! python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --state-file contracts/trustops/agent-authority-current-state.raw-receipt.invalid.json >/tmp/agent-registry-authority-invalid.json
 
 test:
 	python3 -m pytest -q tools/tests

--- a/docs/trustops-authority-state-lookup.md
+++ b/docs/trustops-authority-state-lookup.md
@@ -1,0 +1,103 @@
+# TrustOps Authority State Lookup v0
+
+## Purpose
+
+`tools/authority_state_lookup.py` provides a read-only lookup surface for `AgentAuthorityCurrentState` records.
+
+It exists so AgentPlane and other consumers can resolve current authority posture without reconstructing state from raw TrustOps receipts.
+
+## Command
+
+Lookup by agent ref and status from the local authority-state source directory:
+
+```bash
+python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --status active
+```
+
+Lookup from an explicit validated state file:
+
+```bash
+python3 tools/authority_state_lookup.py get agent-registry://agent-alpha \
+  --state-file contracts/trustops/agent-authority-current-state.suspended.example.json
+```
+
+## Output
+
+Successful lookup emits:
+
+```text
+recordType = AgentAuthorityStateLookupResult
+ok = true
+mode = readonly
+authority_state = AgentAuthorityCurrentState
+```
+
+Failed lookup emits:
+
+```text
+recordType = AgentAuthorityStateLookupError
+ok = false
+mode = readonly
+reason_code = <fail-closed reason>
+```
+
+## Fail-closed reasons
+
+The lookup can fail closed with:
+
+- `state_file_missing`
+- `state_file_invalid_json`
+- `state_file_not_object`
+- `authority_state_invalid`
+- `authority_state_not_found`
+- `authority_state_ambiguous`
+- `authority_state_agent_mismatch`
+- `authority_state_status_mismatch`
+
+## Authority derivation boundary
+
+Lookup returns validated `AgentAuthorityCurrentState` only.
+
+It does not derive current authority state from:
+
+```text
+trustops-receipt:*
+```
+
+Raw TrustOps receipts are evidence, not authority mutation.
+
+Current authority state must derive from explicit authority decisions or restoration decisions, as enforced by `tools/validate_authority_state_contracts.py`.
+
+## AgentPlane consumption
+
+AgentPlane governed-runner admission should consume the lookup result's embedded `authority_state` field as the authority input for `AttemptAdmissionReceipt` construction.
+
+AgentPlane must not compute, mutate, or restore authority state.
+
+## Validation
+
+```bash
+make validate-authority-state-lookup
+python3 -m pytest -q tools/tests/test_authority_state_lookup.py
+```
+
+The tests cover:
+
+- active authority lookup by status;
+- explicit state-file lookup;
+- ambiguous lookup fail-closed;
+- missing state fail-closed;
+- raw-receipt-derived state rejection;
+- agent-ref mismatch fail-closed.
+
+## Non-goals
+
+This lookup does not:
+
+- mutate authority;
+- approve restoration;
+- derive authority state from raw receipts;
+- emit AgentPlane admission receipts;
+- execute agents;
+- run safety preflight;
+- settle budget.

--- a/tools/authority_state_lookup.py
+++ b/tools/authority_state_lookup.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Read-only AgentAuthorityCurrentState lookup helper.
+
+This command resolves a validated AgentAuthorityCurrentState record from an
+explicit state file or from a local source directory. It never derives authority
+state from raw TrustOps receipts and never mutates authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import validate_authority_state_contracts
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE_DIR = ROOT / "contracts" / "trustops"
+NON_GOALS = [
+    "authority_mutation",
+    "restoration_approval",
+    "raw_receipt_to_authority_state_derivation",
+    "agentplane_admission",
+    "runtime_execution",
+]
+
+
+class LookupError(Exception):
+    def __init__(self, reason_code: str, message: str):
+        self.reason_code = reason_code
+        self.message = message
+        super().__init__(message)
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise LookupError("state_file_missing", f"state file does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise LookupError("state_file_invalid_json", f"state file is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise LookupError("state_file_not_object", f"state file must contain a JSON object: {path}")
+    return data
+
+
+def validate_state(record: dict[str, Any]) -> None:
+    try:
+        validate_authority_state_contracts.validate_state(record)
+    except validate_authority_state_contracts.ValidationError as exc:
+        raise LookupError("authority_state_invalid", str(exc)) from exc
+
+
+def state_result(record: dict[str, Any], source_path: Path) -> dict[str, Any]:
+    return {
+        "schemaVersion": "agent-registry.authority-state-lookup.v0.1",
+        "recordType": "AgentAuthorityStateLookupResult",
+        "ok": True,
+        "mode": "readonly",
+        "agentRef": record["agentRef"],
+        "authority_status": record["authority_status"],
+        "stateId": record["stateId"],
+        "state_file": str(source_path),
+        "authority_state": record,
+        "non_goals": NON_GOALS,
+    }
+
+
+def error_result(reason_code: str, message: str, *, agent_ref: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schemaVersion": "agent-registry.authority-state-lookup.v0.1",
+        "recordType": "AgentAuthorityStateLookupError",
+        "ok": False,
+        "mode": "readonly",
+        "reason_code": reason_code,
+        "message": message,
+        "non_goals": NON_GOALS,
+    }
+    if agent_ref:
+        payload["agentRef"] = agent_ref
+    return payload
+
+
+def load_validated_state(path: Path) -> dict[str, Any]:
+    record = load_object(path)
+    validate_state(record)
+    return record
+
+
+def candidate_files(source_dir: Path) -> list[Path]:
+    if not source_dir.exists():
+        return []
+    return sorted(source_dir.glob("agent-authority-current-state.*.json"))
+
+
+def find_state(source_dir: Path, agent_ref: str, status: str | None) -> tuple[dict[str, Any], Path]:
+    matches: list[tuple[dict[str, Any], Path]] = []
+    errors: list[str] = []
+    for path in candidate_files(source_dir):
+        try:
+            record = load_validated_state(path)
+        except LookupError as exc:
+            errors.append(f"{path}: {exc.message}")
+            continue
+        if record.get("agentRef") != agent_ref:
+            continue
+        if status and record.get("authority_status") != status:
+            continue
+        matches.append((record, path))
+
+    if not matches:
+        detail = f"no authority state found for {agent_ref}"
+        if status:
+            detail += f" with status {status}"
+        if errors:
+            detail += f"; skipped invalid states: {'; '.join(errors)}"
+        raise LookupError("authority_state_not_found", detail)
+    if len(matches) > 1:
+        refs = ", ".join(record["stateId"] for record, _path in matches)
+        raise LookupError("authority_state_ambiguous", f"multiple authority states matched {agent_ref}: {refs}")
+    return matches[0]
+
+
+def command_get(args: argparse.Namespace) -> int:
+    try:
+        if args.state_file:
+            path = Path(args.state_file)
+            record = load_validated_state(path)
+            if record.get("agentRef") != args.agent_ref:
+                raise LookupError(
+                    "authority_state_agent_mismatch",
+                    f"state file agentRef {record.get('agentRef')} does not match requested {args.agent_ref}",
+                )
+            if args.status and record.get("authority_status") != args.status:
+                raise LookupError(
+                    "authority_state_status_mismatch",
+                    f"state file status {record.get('authority_status')} does not match requested {args.status}",
+                )
+        else:
+            record, path = find_state(Path(args.source_dir), args.agent_ref, args.status)
+        emit(state_result(record, path))
+        return 0
+    except LookupError as exc:
+        emit(error_result(exc.reason_code, exc.message, agent_ref=args.agent_ref))
+        return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="authority-state-lookup")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    get = sub.add_parser("get", help="Resolve a validated AgentAuthorityCurrentState record.")
+    get.add_argument("agent_ref")
+    get.add_argument("--status", choices=["active", "reduced", "suspended", "revoked"])
+    get.add_argument("--source-dir", default=str(DEFAULT_SOURCE_DIR))
+    get.add_argument("--state-file")
+    get.set_defaults(func=command_get)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tests/test_authority_state_lookup.py
+++ b/tools/tests/test_authority_state_lookup.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+LOOKUP = ROOT / "tools" / "authority_state_lookup.py"
+STATE_DIR = ROOT / "contracts" / "trustops"
+ACTIVE_STATE = STATE_DIR / "agent-authority-current-state.active.example.json"
+SUSPENDED_STATE = STATE_DIR / "agent-authority-current-state.suspended.example.json"
+RAW_RECEIPT_STATE = STATE_DIR / "agent-authority-current-state.raw-receipt.invalid.json"
+
+
+def run_lookup(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(LOOKUP), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_lookup_active_state_by_status() -> None:
+    result = run_lookup(
+        "get",
+        "agent-registry://agent-alpha",
+        "--status",
+        "active",
+        "--source-dir",
+        str(STATE_DIR),
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "AgentAuthorityStateLookupResult"
+    assert payload["ok"] is True
+    assert payload["mode"] == "readonly"
+    assert payload["authority_status"] == "active"
+    assert payload["authority_state"]["recordType"] == "AgentAuthorityCurrentState"
+    assert "authority_mutation" in payload["non_goals"]
+
+
+def test_lookup_explicit_state_file() -> None:
+    result = run_lookup(
+        "get",
+        "agent-registry://agent-alpha",
+        "--state-file",
+        str(SUSPENDED_STATE),
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["authority_status"] == "suspended"
+    assert payload["state_file"] == str(SUSPENDED_STATE)
+
+
+def test_lookup_ambiguous_without_status_fails_closed() -> None:
+    result = run_lookup(
+        "get",
+        "agent-registry://agent-alpha",
+        "--source-dir",
+        str(STATE_DIR),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["recordType"] == "AgentAuthorityStateLookupError"
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "authority_state_ambiguous"
+
+
+def test_lookup_missing_state_fails_closed(tmp_path: Path) -> None:
+    result = run_lookup(
+        "get",
+        "agent-registry://missing-agent",
+        "--source-dir",
+        str(tmp_path),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "authority_state_not_found"
+
+
+def test_lookup_rejects_raw_receipt_derived_state() -> None:
+    result = run_lookup(
+        "get",
+        "agent-registry://agent-alpha",
+        "--state-file",
+        str(RAW_RECEIPT_STATE),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "authority_state_invalid"
+    assert "raw TrustOps receipt" in payload["message"]
+
+
+def test_lookup_agent_mismatch_fails_closed() -> None:
+    result = run_lookup(
+        "get",
+        "agent-registry://different-agent",
+        "--state-file",
+        str(ACTIVE_STATE),
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["reason_code"] == "authority_state_agent_mismatch"


### PR DESCRIPTION
## Summary

Implements the read-only authority-state lookup surface for governed-runner admission, resolving `agent-registry#38`.

The lookup returns validated `AgentAuthorityCurrentState` records only. It does not derive authority state from raw TrustOps receipts and does not mutate authority.

## Adds

- `tools/authority_state_lookup.py`
- `tools/tests/test_authority_state_lookup.py`
- `docs/trustops-authority-state-lookup.md`
- `validate-authority-state-lookup` Makefile target

## Commands

Lookup by agent ref and status:

```bash
python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --status active
```

Lookup from an explicit state file:

```bash
python3 tools/authority_state_lookup.py get agent-registry://agent-alpha \
  --state-file contracts/trustops/agent-authority-current-state.suspended.example.json
```

## Fail-closed behavior

The command emits `AgentAuthorityStateLookupError` for:

- missing state file
- invalid JSON
- non-object state payload
- invalid authority state
- state not found
- ambiguous state matches
- agent mismatch
- status mismatch

## Boundary

- no authority mutation
- no restoration approval
- no raw receipt to authority-state derivation
- no AgentPlane admission emission
- no runtime execution
- no safety preflight
- no budget settlement

## Validation

```bash
make validate-authority-state-lookup
python3 -m pytest -q tools/tests/test_authority_state_lookup.py
```