### PR TITLE
Add Workspace Context authority binding v0.1 current-main replay

### DIFF
--- a/.github/workflows/workspace-context-authority-binding.yml
+++ b/.github/workflows/workspace-context-authority-binding.yml
@@ -1,0 +1,34 @@
+name: workspace-context-authority-binding
+
+on:
+  pull_request:
+    paths:
+      - "docs/workspace-context-authority-binding.md"
+      - "contracts/workspace-context/**"
+      - "tools/validate_workspace_context_authority_binding.py"
+      - ".github/workflows/workspace-context-authority-binding.yml"
+      - "Makefile"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/workspace-context-authority-binding.md"
+      - "contracts/workspace-context/**"
+      - "tools/validate_workspace_context_authority_binding.py"
+      - ".github/workflows/workspace-context-authority-binding.yml"
+      - "Makefile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-workspace-context-authority-binding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate Workspace Context authority binding
+        run: make validate-workspace-context-authority-binding

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -35,6 +35,11 @@ validate-authority-state-lookup:
 	python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --status active >/tmp/agent-registry-authority-active.json
 	python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --state-file contracts/trustops/agent-authority-current-state.suspended.example.json >/tmp/agent-registry-authority-suspended.json
 	! python3 tools/authority_state_lookup.py get agent-registry://agent-alpha --state-file contracts/trustops/agent-authority-current-state.raw-receipt.invalid.json >/tmp/agent-registry-authority-invalid.json
+
+validate-workspace-context-authority-binding:
+	python3 -m json.tool contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json >/dev/null
+	python3 tools/validate_workspace_context_authority_binding.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json
+++ b/contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "agent-registry.workspace-context-authority-binding.v0.1",
+  "recordType": "WorkspaceContextAuthorityBinding",
+  "bindingId": "workspace-context-authority-binding-demo-0001",
+  "createdAt": "2026-05-22T17:05:00Z",
+  "workroomRef": "workroom://workroom-demo-0001",
+  "professionalWorkroomRef": "professional-workroom://workroom-demo-0001",
+  "contextGraphRef": "ctxgraph-demo-0001",
+  "runtimeBindingRef": "runtime-binding-demo-0001",
+  "agentRefs": [
+    "agent-registry://agents/context-fabric-reviewer"
+  ],
+  "sessionRefs": [
+    "urn:srcos:session:context-fabric-demo-0001"
+  ],
+  "authorityStateRefs": [
+    "agent-authority-current-state:context-fabric-reviewer:active"
+  ],
+  "grantRefs": [
+    "agent-registry://grants/context-fabric-demo-0001"
+  ],
+  "revocationRefs": [],
+  "policyRefs": [
+    "policy-decision://policy-demo-ai-use/decision-0001"
+  ],
+  "evidenceRefs": [
+    "agentplane://evidence/workroom-context-demo-0001",
+    "platform://workspace-context-record-demo-0001"
+  ],
+  "status": "active",
+  "labels": {
+    "surface": "workspace-context",
+    "fixture": "public-synthetic"
+  }
+}

--- a/contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json
+++ b/contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/workspace-context/workspace-context-authority-binding.v0.1.schema.json",
+  "title": "WorkspaceContextAuthorityBinding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "bindingId",
+    "createdAt",
+    "workroomRef",
+    "contextGraphRef",
+    "runtimeBindingRef",
+    "agentRefs",
+    "sessionRefs",
+    "authorityStateRefs",
+    "grantRefs",
+    "policyRefs",
+    "evidenceRefs",
+    "status"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agent-registry.workspace-context-authority-binding.v0.1"},
+    "recordType": {"const": "WorkspaceContextAuthorityBinding"},
+    "bindingId": {"type": "string"},
+    "createdAt": {"type": "string"},
+    "workroomRef": {"type": "string"},
+    "professionalWorkroomRef": {"type": ["string", "null"]},
+    "contextGraphRef": {"type": "string"},
+    "runtimeBindingRef": {"type": "string"},
+    "agentRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "sessionRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "authorityStateRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "grantRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "revocationRefs": {"type": "array", "items": {"type": "string"}},
+    "policyRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "evidenceRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "status": {"type": "string", "enum": ["active", "reduced", "suspended", "revoked", "review"]},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/docs/workspace-context-authority-binding.md
+++ b/docs/workspace-context-authority-binding.md
@@ -1,0 +1,63 @@
+# Workspace Context Authority Binding
+
+## Purpose
+
+This document defines the Agent Registry authority-side binding for Prophet Workspace Context Fabric.
+
+Prophet Workspace owns Workroom and Context Fabric semantics. Agent Registry owns the agent, session, authority-state, grant, revocation, policy, and evidence references consumed by workspace runtime bindings.
+
+## Object
+
+The first binding object is:
+
+```text
+contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json
+contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json
+```
+
+## Boundary
+
+Agent Registry does not store workspace context graphs and does not own context-pack memory.
+
+Agent Registry records the authority references needed for a workroom runtime binding to be admitted and audited.
+
+The binding includes:
+
+- workroom ref;
+- optional professional workroom ref;
+- context graph ref;
+- runtime binding ref;
+- agent refs;
+- session refs;
+- authority current-state refs;
+- grant refs;
+- revocation refs;
+- evidence refs;
+- policy refs.
+
+## Plane ownership
+
+| Concern | Owner |
+|---|---|
+| Workroom and Context Fabric semantics | Prophet Workspace |
+| Authority refs, grants, revocations, sessions | Agent Registry |
+| Execution evidence | AgentPlane |
+| Recall and context packs | Memory Mesh |
+| Runtime and product evidence records | Prophet Platform |
+
+## Validation
+
+```bash
+make validate-workspace-context-authority-binding
+```
+
+## Non-goals
+
+This binding does not:
+
+- store workspace context graphs;
+- store raw context packs;
+- grant runtime authority by itself;
+- execute work;
+- replace AgentPlane execution evidence;
+- replace Memory Mesh recall authority.

--- a/tools/validate_workspace_context_authority_binding.py
+++ b/tools/validate_workspace_context_authority_binding.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json"
+EXAMPLE = ROOT / "contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json"
+
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "bindingId",
+    "createdAt",
+    "workroomRef",
+    "contextGraphRef",
+    "runtimeBindingRef",
+    "agentRefs",
+    "sessionRefs",
+    "authorityStateRefs",
+    "grantRefs",
+    "policyRefs",
+    "evidenceRefs",
+    "status",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail("expected object")
+    return payload
+
+
+def need_str(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def need_list(record: dict[str, Any], key: str) -> list[str]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{key}: expected non-empty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            fail(f"{key}[{index}]: expected non-empty string")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    missing = sorted(REQUIRED - set(schema.get("required", [])))
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agent-registry.workspace-context-authority-binding.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "WorkspaceContextAuthorityBinding":
+        fail("recordType const mismatch")
+
+
+def validate_example(example: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(example))
+    if missing:
+        fail(f"example missing required fields: {missing}")
+    if example["schemaVersion"] != "agent-registry.workspace-context-authority-binding.v0.1":
+        fail("schemaVersion mismatch")
+    if example["recordType"] != "WorkspaceContextAuthorityBinding":
+        fail("recordType mismatch")
+    if not need_str(example, "workroomRef").startswith("workroom://"):
+        fail("workroomRef must use workroom://")
+    if example.get("professionalWorkroomRef") is not None and not str(example["professionalWorkroomRef"]).startswith("professional-workroom://"):
+        fail("professionalWorkroomRef must use professional-workroom:// when present")
+    need_str(example, "contextGraphRef")
+    need_str(example, "runtimeBindingRef")
+    for key in ("agentRefs", "sessionRefs", "authorityStateRefs", "grantRefs", "policyRefs", "evidenceRefs"):
+        need_list(example, key)
+    if not isinstance(example.get("revocationRefs", []), list):
+        fail("revocationRefs must be list when present")
+    if example["status"] not in {"active", "reduced", "suspended", "revoked", "review"}:
+        fail("invalid status")
+
+
+def main() -> int:
+    try:
+        validate_schema(load(SCHEMA))
+        validate_example(load(EXAMPLE))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print("OK: WorkspaceContextAuthorityBinding validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Current-main replay of `agent-registry#37` with the CodeQL workflow permissions finding fixed.

Adds the Agent Registry authority-side binding for Prophet Workspace Context Fabric.

`prophet-workspace` owns Workroom and Context Fabric semantics. Agent Registry owns the agent/session/authority-state/grant/revocation refs consumed by workspace runtime bindings.

## Replays from

- Supersedes stale PR: `SocioProphet/agent-registry#37`

## Adds

- `docs/workspace-context-authority-binding.md`
- `contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json`
- `contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json`
- `tools/validate_workspace_context_authority_binding.py`
- `validate-workspace-context-authority-binding` Makefile target
- `.github/workflows/workspace-context-authority-binding.yml`

## Improvement over stale PR

Adds explicit workflow permissions:

```yaml
permissions:
  contents: read
```

This resolves the CodeQL finding on the original PR.

## Boundary

- Agent Registry does not store workspace context graphs.
- Agent Registry owns authority refs used by workroom runtime bindings.
- AgentPlane remains execution evidence authority.
- Memory Mesh remains recall/context-pack authority.
- Prophet Platform remains runtime/evidence record authority.

## Validation

```bash
make validate-workspace-context-authority-binding
```