### PR TITLE
Add control-plane capability grant contract

### DIFF
--- a/.github/workflows/control-plane-capability-grant.yml
+++ b/.github/workflows/control-plane-capability-grant.yml
@@ -1,0 +1,34 @@
+name: control-plane-capability-grant
+
+on:
+  pull_request:
+    paths:
+      - "docs/control-plane-grants-and-runtime-authority.md"
+      - "contracts/control-plane/**"
+      - "tools/validate_control_plane_capability_grant.py"
+      - ".github/workflows/control-plane-capability-grant.yml"
+      - "Makefile"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/control-plane-grants-and-runtime-authority.md"
+      - "contracts/control-plane/**"
+      - "tools/validate_control_plane_capability_grant.py"
+      - ".github/workflows/control-plane-capability-grant.yml"
+      - "Makefile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-control-plane-capability-grant:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate control-plane capability grant
+        run: make validate-control-plane-capability-grant

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding validate-control-plane-capability-grant
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding validate-control-plane-capability-grant
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -40,6 +40,11 @@ validate-workspace-context-authority-binding:
 	python3 -m json.tool contracts/workspace-context/workspace-context-authority-binding.v0.1.schema.json >/dev/null
 	python3 -m json.tool contracts/workspace-context/workspace-context-authority-binding.v0.1.example.json >/dev/null
 	python3 tools/validate_workspace_context_authority_binding.py
+
+validate-control-plane-capability-grant:
+	python3 -m json.tool contracts/control-plane/control-plane-capability-grant.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/control-plane/control-plane-capability-grant.v0.1.example.json >/dev/null
+	python3 tools/validate_control_plane_capability_grant.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/contracts/control-plane/control-plane-capability-grant.v0.1.example.json
+++ b/contracts/control-plane/control-plane-capability-grant.v0.1.example.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "agent-registry.control-plane-capability-grant.v0.1",
+  "recordType": "ControlPlaneCapabilityGrant",
+  "grantId": "grant-control-plane-matrix-triage-001",
+  "subjectAgent": "agent://matrix-triage-assistant",
+  "authorityClass": "tool_grant",
+  "allowedScopes": [
+    "matrix.room.read",
+    "case.intake.summarize",
+    "support.ticket.propose"
+  ],
+  "deniedScopes": [
+    "case.record.mutate",
+    "matrix.room.publish",
+    "production.deploy"
+  ],
+  "runtimeAuthority": {
+    "state": "active",
+    "expiresAt": "2026-05-07T23:59:59Z",
+    "revoked": false,
+    "revocationReason": null
+  },
+  "policyRef": "policy-fabric://control-plane/matrix-triage-readonly-v0",
+  "delegationRef": null,
+  "admissionRef": null,
+  "notes": "Read-only public-intake grant fixture. Broker enforcement belongs in mcp-a2a-zero-trust. Execution admission, when needed, belongs in agentplane.",
+  "labels": {
+    "fixture": "public-synthetic",
+    "surface": "control-plane"
+  }
+}

--- a/contracts/control-plane/control-plane-capability-grant.v0.1.schema.json
+++ b/contracts/control-plane/control-plane-capability-grant.v0.1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/control-plane/control-plane-capability-grant.v0.1.schema.json",
+  "title": "ControlPlaneCapabilityGrant",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "grantId",
+    "subjectAgent",
+    "authorityClass",
+    "allowedScopes",
+    "deniedScopes",
+    "runtimeAuthority",
+    "policyRef"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agent-registry.control-plane-capability-grant.v0.1"},
+    "recordType": {"const": "ControlPlaneCapabilityGrant"},
+    "grantId": {"type": "string"},
+    "subjectAgent": {"type": "string"},
+    "authorityClass": {"type": "string", "enum": ["tool_grant", "event_read", "event_write", "context_read", "bridge_export"]},
+    "allowedScopes": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "deniedScopes": {"type": "array", "items": {"type": "string"}},
+    "runtimeAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "expiresAt", "revoked"],
+      "properties": {
+        "state": {"type": "string", "enum": ["active", "reduced", "suspended", "revoked"]},
+        "expiresAt": {"type": "string"},
+        "revoked": {"type": "boolean"},
+        "revocationReason": {"type": ["string", "null"]}
+      }
+    },
+    "policyRef": {"type": "string"},
+    "delegationRef": {"type": ["string", "null"]},
+    "admissionRef": {"type": ["string", "null"]},
+    "notes": {"type": "string"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  }
+}

--- a/docs/control-plane-grants-and-runtime-authority.md
+++ b/docs/control-plane-grants-and-runtime-authority.md
@@ -1,0 +1,62 @@
+# Control-Plane Grants and Runtime Authority
+
+## Purpose
+
+This document records the Agent Registry side of the Matrix / MCP / A2A / capability-lease control-plane slice.
+
+## Role
+
+Agent Registry is the canonical registry for:
+
+- agent specifications;
+- agent identities;
+- sessions;
+- tool grants;
+- grant revocation;
+- runtime authority records.
+
+It does not own broker enforcement, deployment topology, Matrix room policy, or execution runtime.
+
+## Boundary split
+
+| Concern | Owner |
+|---|---|
+| Grant and runtime-authority records | `agent-registry` |
+| Broker enforcement and zero-trust checks | `mcp-a2a-zero-trust` |
+| Human delegation and consent authority | `HolographMe` |
+| Execution admission and run/replay evidence | `agentplane` |
+| Policy approvals and compiled policy evidence | `policy-fabric` |
+
+## Contract
+
+The first contract is:
+
+```text
+contracts/control-plane/control-plane-capability-grant.v0.1.schema.json
+contracts/control-plane/control-plane-capability-grant.v0.1.example.json
+```
+
+A control-plane capability grant records:
+
+- stable grant identifier;
+- subject agent;
+- authority class;
+- allowed scopes;
+- denied scopes;
+- runtime authority status;
+- expiry;
+- policy reference;
+- optional delegation reference;
+- optional admission reference.
+
+## Non-goals
+
+This tranche does not implement broker enforcement.
+
+Broker/enforcement implementation belongs in `mcp-a2a-zero-trust` and should consume Agent Registry decisions rather than redefine them.
+
+## Validation
+
+```bash
+make validate-control-plane-capability-grant
+```

--- a/tools/validate_control_plane_capability_grant.py
+++ b/tools/validate_control_plane_capability_grant.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts/control-plane/control-plane-capability-grant.v0.1.schema.json"
+EXAMPLE = ROOT / "contracts/control-plane/control-plane-capability-grant.v0.1.example.json"
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "grantId",
+    "subjectAgent",
+    "authorityClass",
+    "allowedScopes",
+    "deniedScopes",
+    "runtimeAuthority",
+    "policyRef",
+}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail("expected object")
+    return payload
+
+
+def need_str(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def need_list(record: dict[str, Any], key: str, *, non_empty: bool = False) -> list[str]:
+    value = record.get(key)
+    if not isinstance(value, list):
+        fail(f"{key}: expected list")
+    if non_empty and not value:
+        fail(f"{key}: expected non-empty list")
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            fail(f"{key}[{index}]: expected non-empty string")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    missing = sorted(REQUIRED - set(schema.get("required", [])))
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+    props = schema.get("properties", {})
+    if props.get("schemaVersion", {}).get("const") != "agent-registry.control-plane-capability-grant.v0.1":
+        fail("schemaVersion const mismatch")
+    if props.get("recordType", {}).get("const") != "ControlPlaneCapabilityGrant":
+        fail("recordType const mismatch")
+
+
+def validate_example(example: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(example))
+    if missing:
+        fail(f"example missing required fields: {missing}")
+    if example["schemaVersion"] != "agent-registry.control-plane-capability-grant.v0.1":
+        fail("schemaVersion mismatch")
+    if example["recordType"] != "ControlPlaneCapabilityGrant":
+        fail("recordType mismatch")
+    if not need_str(example, "subjectAgent").startswith("agent://"):
+        fail("subjectAgent must use agent://")
+    if example["authorityClass"] not in {"tool_grant", "event_read", "event_write", "context_read", "bridge_export"}:
+        fail("invalid authorityClass")
+    allowed = set(need_list(example, "allowedScopes", non_empty=True))
+    denied = set(need_list(example, "deniedScopes"))
+    if allowed & denied:
+        fail("allowedScopes and deniedScopes overlap")
+    need_str(example, "policyRef")
+    runtime = example.get("runtimeAuthority")
+    if not isinstance(runtime, dict):
+        fail("runtimeAuthority must be object")
+    state = need_str(runtime, "state")
+    if state not in {"active", "reduced", "suspended", "revoked"}:
+        fail("invalid runtimeAuthority.state")
+    if not isinstance(runtime.get("revoked"), bool):
+        fail("runtimeAuthority.revoked must be boolean")
+    if state == "revoked" and runtime.get("revoked") is not True:
+        fail("revoked state requires revoked=true")
+    if runtime.get("revoked") is True and not runtime.get("revocationReason"):
+        fail("revoked grant requires revocationReason")
+    need_str(runtime, "expiresAt")
+
+
+def main() -> int:
+    try:
+        validate_schema(load(SCHEMA))
+        validate_example(load(EXAMPLE))
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print("OK: ControlPlaneCapabilityGrant validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Current-main replay and hardening of stale draft PR `agent-registry#31`.

Defines the Agent Registry side of the Matrix / MCP / A2A / capability-lease control-plane slice as a validated contract instead of docs-only draft work.

## Replays from

- Supersedes stale draft PR: `SocioProphet/agent-registry#31`

## Adds

- `docs/control-plane-grants-and-runtime-authority.md`
- `contracts/control-plane/control-plane-capability-grant.v0.1.schema.json`
- `contracts/control-plane/control-plane-capability-grant.v0.1.example.json`
- `tools/validate_control_plane_capability_grant.py`
- `validate-control-plane-capability-grant` Makefile target
- `.github/workflows/control-plane-capability-grant.yml`

## Boundary

- Agent Registry owns grant and runtime-authority records.
- `mcp-a2a-zero-trust` owns broker/enforcement and zero-trust boundary checks.
- `HolographMe` owns human delegation and consent authority.
- `agentplane` owns execution admission and run/replay evidence.
- `policy-fabric` owns policy approvals and compiled policy evidence.

## Validation

```bash
make validate-control-plane-capability-grant
```

## Non-goals

No broker enforcement, runtime execution, deployment topology, policy evaluation, credential storage, or provider integration is added.