### PR TITLE
Harden TrustOps authority decision semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ validate-trustops-agent-authority-decision:
 	python3 -m json.tool contracts/trustops/agent-authority-decision.v0.1.example.json >/dev/null
 	python3 -m json.tool contracts/trustops/agent-authority-decision.pass-revoked.invalid.json >/dev/null
 	python3 -m json.tool contracts/trustops/agent-authority-decision.missing-decision-authority.invalid.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-decision.require-review-unchanged.invalid.json >/dev/null
+	python3 -m json.tool contracts/trustops/agent-authority-decision.revoke-reduced.invalid.json >/dev/null
 	python3 tools/validate_trustops_agent_authority_decision.py
 
 validate-authority-state-contracts:

--- a/contracts/trustops/agent-authority-decision.require-review-unchanged.invalid.json
+++ b/contracts/trustops/agent-authority-decision.require-review-unchanged.invalid.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "agent-registry.trustops-agent-authority-decision.v0.1",
+  "recordType": "TrustOpsAgentAuthorityDecision",
+  "recordId": "trustops-agent-authority-decision:agent-alpha-invalid-review-unchanged",
+  "agentRef": "agent-registry://agent-alpha",
+  "receiptRef": "trustops-receipt:agent-alpha-review-001",
+  "receipt_outcome": "require-review",
+  "authority_decision": "unchanged",
+  "decision_actor_ref": "service://trustops-authority-evaluator-v0.1",
+  "decision_actor_kind": "service",
+  "decision_authority_ref": "authority://agent-registry/trustops-agent-authority-update",
+  "authorization_policy_ref": "policy://trustops/agent-authority-v0.1",
+  "authorization_evidence_refs": [
+    "policy://trustops/agent-authority-v0.1",
+    "trustops-receipt:agent-alpha-review-001"
+  ],
+  "effective_at": "2026-05-26T20:10:00Z",
+  "decision_timestamp": "2026-05-26T20:09:00Z",
+  "policyRefs": ["policy://trustops/agent-authority-v0.1"],
+  "gateRefs": ["gate://trustops/high-uncertainty-human-review"],
+  "evidenceRefs": ["trustops-receipt:agent-alpha-review-001"],
+  "authorityEffects": {
+    "toolAccess": "unchanged",
+    "memoryAccess": "unchanged",
+    "autonomousExecution": "unchanged",
+    "routeEligibility": "unchanged",
+    "egressMode": "unchanged"
+  },
+  "restored_by_policy": {
+    "allowed": true,
+    "policyRef": "policy://trustops/agent-authority-restoration-v0.1",
+    "restoration_conditions": ["fresh passing TrustOps receipt"]
+  },
+  "labels": {
+    "issue": "SocioProphet/agent-registry#17",
+    "fixture": "require-review-unchanged-invalid"
+  }
+}

--- a/contracts/trustops/agent-authority-decision.revoke-reduced.invalid.json
+++ b/contracts/trustops/agent-authority-decision.revoke-reduced.invalid.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": "agent-registry.trustops-agent-authority-decision.v0.1",
+  "recordType": "TrustOpsAgentAuthorityDecision",
+  "recordId": "trustops-agent-authority-decision:agent-alpha-invalid-revoke-reduced",
+  "agentRef": "agent-registry://agent-alpha",
+  "receiptRef": "trustops-receipt:agent-alpha-revoke-001",
+  "receipt_outcome": "revoke",
+  "authority_decision": "reduced",
+  "decision_actor_ref": "service://trustops-authority-evaluator-v0.1",
+  "decision_actor_kind": "service",
+  "decision_authority_ref": "authority://agent-registry/trustops-agent-authority-update",
+  "authorization_policy_ref": "policy://trustops/agent-authority-v0.1",
+  "authorization_evidence_refs": [
+    "policy://trustops/agent-authority-v0.1",
+    "trustops-receipt:agent-alpha-revoke-001"
+  ],
+  "effective_at": "2026-05-26T20:11:00Z",
+  "decision_timestamp": "2026-05-26T20:10:00Z",
+  "policyRefs": ["policy://trustops/agent-authority-v0.1"],
+  "gateRefs": ["gate://trustops/tool-abuse-revoke"],
+  "evidenceRefs": ["trustops-receipt:agent-alpha-revoke-001"],
+  "authorityEffects": {
+    "toolAccess": "reduced",
+    "memoryAccess": "reduced",
+    "autonomousExecution": "require-human-approval",
+    "routeEligibility": "reduced",
+    "egressMode": "restricted"
+  },
+  "restored_by_policy": {
+    "allowed": false,
+    "policyRef": "policy://trustops/no-restore"
+  },
+  "labels": {
+    "issue": "SocioProphet/agent-registry#17",
+    "fixture": "revoke-reduced-invalid"
+  }
+}

--- a/docs/trustops-authority-current-state.md
+++ b/docs/trustops-authority-current-state.md
@@ -21,6 +21,48 @@ Guardrail Fabric owns TrustOps runtime action mapping.
 
 AgentPlane consumes current authority state during attempt admission.
 
+## Receipt evidence versus authority decision
+
+The registry keeps the TrustOps receipt outcome separate from the governed authority decision.
+
+A TrustOps receipt records what happened at a trust or safety gate:
+
+```text
+pass | warn | require-review | quarantine | block | rollback | revoke
+```
+
+An authority decision records what the registry decided to do to runtime authority:
+
+```text
+unchanged | reduced | suspended | revoked
+```
+
+Those fields must not collapse into a generic success flag. A high-uncertainty `require-review` receipt is not equivalent to a hard tool-abuse `revoke` receipt, and neither is itself the current authority state. The decision carries its own actor, policy, evidence, gate refs, `effective_at`, and restoration posture.
+
+## Authority-decision semantic rules
+
+The validator enforces the following receipt-to-authority bounds:
+
+| TrustOps receipt outcome | Required authority posture |
+|---|---|
+| `pass` | `unchanged` only |
+| `warn` | at most `reduced` |
+| `require-review` | exactly `reduced` with `autonomousExecution=require-human-approval` |
+| `quarantine` | exactly `suspended` |
+| `block` | exactly `suspended` |
+| `rollback` | exactly `suspended` |
+| `revoke` | exactly `revoked` |
+
+Additional effect rules:
+
+- `authority_decision=unchanged` requires all `authorityEffects` to remain `unchanged`.
+- Non-unchanged authority decisions require at least one changed authority effect.
+- `quarantine`, `block`, and `rollback` suspend autonomous execution and block egress.
+- `revoke` revokes tool access, memory access, autonomous execution, and route eligibility, and blocks egress.
+- Any non-unchanged authority decision requires authorization evidence refs.
+
+These rules preserve the audit seam: receipt as evidence, authority change as governed decision.
+
 ## Current state
 
 The current-state record includes:
@@ -67,6 +109,7 @@ Restoration requires:
 
 ```bash
 make validate-authority-state-contracts
+make validate-trustops-agent-authority-decision
 ```
 
 The validator checks:
@@ -75,6 +118,10 @@ The validator checks:
 - restoration decision fixture
 - missing restoration authorization negative fixture
 - raw-receipt-derived current-state negative fixture
+- TrustOps authority-decision receipt/authority separation
+- invalid pass-to-revoked authority escalation
+- invalid require-review-with-unchanged authority
+- invalid revoke-with-only-reduced authority
 
 ## Non-goals
 

--- a/tools/validate_trustops_agent_authority_decision.py
+++ b/tools/validate_trustops_agent_authority_decision.py
@@ -13,6 +13,8 @@ SCHEMA = ROOT / "contracts" / "trustops" / "agent-authority-decision.v0.1.schema
 EXAMPLE = ROOT / "contracts" / "trustops" / "agent-authority-decision.v0.1.example.json"
 INVALID_PASS_REVOKED = ROOT / "contracts" / "trustops" / "agent-authority-decision.pass-revoked.invalid.json"
 INVALID_MISSING_AUTHORITY = ROOT / "contracts" / "trustops" / "agent-authority-decision.missing-decision-authority.invalid.json"
+INVALID_REVIEW_UNCHANGED = ROOT / "contracts" / "trustops" / "agent-authority-decision.require-review-unchanged.invalid.json"
+INVALID_REVOKE_REDUCED = ROOT / "contracts" / "trustops" / "agent-authority-decision.revoke-reduced.invalid.json"
 
 REQUIRED_TOP_LEVEL = {
     "schemaVersion",
@@ -63,7 +65,16 @@ MAX_AUTHORITY_BY_RECEIPT = {
     "revoke": "revoked",
 }
 
+MIN_AUTHORITY_BY_RECEIPT = {
+    "require-review": "reduced",
+    "quarantine": "suspended",
+    "block": "suspended",
+    "rollback": "suspended",
+    "revoke": "revoked",
+}
+
 DECISION_ACTOR_KINDS = {"human", "policy-engine", "service", "governance-agent"}
+ACCESS_EFFECTS = {"toolAccess", "memoryAccess", "routeEligibility"}
 
 
 class ValidationError(Exception):
@@ -122,6 +133,58 @@ def validate_schema(schema: dict[str, Any]) -> None:
         fail("decision_actor_kind enum mismatch")
 
 
+def validate_authority_bound(receipt_outcome: str, authority_decision: str) -> None:
+    max_authority = MAX_AUTHORITY_BY_RECEIPT[receipt_outcome]
+    if AUTHORITY_RANK[authority_decision] > AUTHORITY_RANK[max_authority]:
+        fail(
+            "authority_decision exceeds receipt_outcome bound: "
+            f"{receipt_outcome} -> {authority_decision}"
+        )
+
+    min_authority = MIN_AUTHORITY_BY_RECEIPT.get(receipt_outcome)
+    if min_authority and AUTHORITY_RANK[authority_decision] < AUTHORITY_RANK[min_authority]:
+        fail(
+            "authority_decision is too weak for receipt_outcome: "
+            f"{receipt_outcome} -> {authority_decision}"
+        )
+
+
+def validate_effects(receipt_outcome: str, authority_decision: str, effects: dict[str, Any]) -> None:
+    for key in ("toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode"):
+        require_non_empty_string(effects, key)
+
+    changed = any(value != "unchanged" for value in effects.values())
+    if authority_decision == "unchanged" and changed:
+        fail("authority_decision=unchanged requires unchanged authorityEffects")
+    if authority_decision != "unchanged" and not changed:
+        fail("non-unchanged authority_decision requires changed authorityEffects")
+
+    if receipt_outcome == "require-review":
+        if authority_decision != "reduced":
+            fail("require-review receipt_outcome must reduce authority")
+        if effects.get("autonomousExecution") != "require-human-approval":
+            fail("require-review must require human approval for autonomousExecution")
+
+    if receipt_outcome in {"quarantine", "block", "rollback"}:
+        if authority_decision != "suspended":
+            fail(f"{receipt_outcome} receipt_outcome must suspend authority")
+        if effects.get("autonomousExecution") != "suspended":
+            fail(f"{receipt_outcome} must suspend autonomousExecution")
+        if effects.get("egressMode") != "blocked":
+            fail(f"{receipt_outcome} must block egressMode")
+
+    if receipt_outcome == "revoke":
+        if authority_decision != "revoked":
+            fail("revoke receipt_outcome must revoke authority")
+        for key in ACCESS_EFFECTS:
+            if effects.get(key) != "revoked":
+                fail(f"revoke must set {key}=revoked")
+        if effects.get("autonomousExecution") != "revoked":
+            fail("revoke must revoke autonomousExecution")
+        if effects.get("egressMode") != "blocked":
+            fail("revoke must block egressMode")
+
+
 def validate_record(record: dict[str, Any]) -> None:
     missing = sorted(REQUIRED_TOP_LEVEL - set(record))
     if missing:
@@ -160,15 +223,7 @@ def validate_record(record: dict[str, Any]) -> None:
     if authority_decision not in AUTHORITY_RANK:
         fail(f"unknown authority_decision: {authority_decision}")
 
-    max_authority = MAX_AUTHORITY_BY_RECEIPT[receipt_outcome]
-    if AUTHORITY_RANK[authority_decision] > AUTHORITY_RANK[max_authority]:
-        fail(
-            "authority_decision exceeds receipt_outcome bound: "
-            f"{receipt_outcome} -> {authority_decision}"
-        )
-
-    if receipt_outcome in {"block", "rollback", "revoke"} and authority_decision == "unchanged":
-        fail(f"{receipt_outcome} cannot leave authority unchanged")
+    validate_authority_bound(receipt_outcome, authority_decision)
 
     if authority_decision != "unchanged":
         require_non_empty_list(record, "authorization_evidence_refs")
@@ -176,8 +231,7 @@ def validate_record(record: dict[str, Any]) -> None:
     effects = record.get("authorityEffects")
     if not isinstance(effects, dict):
         fail("authorityEffects must be an object")
-    for key in ("toolAccess", "memoryAccess", "autonomousExecution", "routeEligibility", "egressMode"):
-        require_non_empty_string(effects, key)
+    validate_effects(receipt_outcome, authority_decision, effects)
 
     restored = record.get("restored_by_policy")
     if not isinstance(restored, dict):
@@ -205,6 +259,8 @@ def main() -> int:
         validate_record(load_json(EXAMPLE))
         expect_invalid(INVALID_PASS_REVOKED, "pass-revoked")
         expect_invalid(INVALID_MISSING_AUTHORITY, "missing-decision-authority")
+        expect_invalid(INVALID_REVIEW_UNCHANGED, "require-review-unchanged")
+        expect_invalid(INVALID_REVOKE_REDUCED, "revoke-reduced")
     except ValidationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

Hardens the TrustOps receipt outcome → agent authority decision boundary from #17.

Keesan's latest comment names the right seam: TrustOps receipt outcomes are evidence; governed runtime authority changes are separate decisions. This PR keeps that split explicit by tightening validator semantics and adding negative fixtures for the two states that would otherwise silently collapse the boundary.

## Adds

- `contracts/trustops/agent-authority-decision.require-review-unchanged.invalid.json`
- `contracts/trustops/agent-authority-decision.revoke-reduced.invalid.json`

## Updates

- `tools/validate_trustops_agent_authority_decision.py`
  - enforces minimum and maximum authority decision bounds per receipt outcome;
  - rejects `require-review` when authority remains unchanged;
  - requires `require-review` to reduce authority and set `autonomousExecution=require-human-approval`;
  - requires `quarantine`, `block`, and `rollback` to suspend authority, suspend autonomous execution, and block egress;
  - requires `revoke` to revoke authority and revoke tool/memory/autonomous/route access while blocking egress;
  - rejects changed `authorityEffects` when `authority_decision=unchanged`;
  - rejects unchanged authority effects when authority changed.
- `Makefile`
  - JSON-checks new negative fixtures.
- `docs/trustops-authority-current-state.md`
  - documents receipt evidence vs governed authority decision as the core audit seam.

## Boundary

This PR does not change TrustOps receipt schema, execute agents, run safety preflight, emit AgentPlane attempt admissions, or introduce a runtime implementation dependency. It only hardens the registry-side authority decision contract.

Advances #17.