### PR TITLE
Add WallGuard agent wall-context contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding validate-control-plane-capability-grant
+.PHONY: validate validate-workspace-ops test release-dry-run ops-history-grants-validate validate-superconscious-reasoning-grant validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding validate-control-plane-capability-grant validate-agent-wall-context
 
-validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding validate-control-plane-capability-grant
+validate: ops-history-grants-validate validate-superconscious-reasoning-grant validate-workspace-ops validate-trustops-agent-authority-decision validate-authority-state-contracts validate-authority-state-lookup validate-workspace-context-authority-binding validate-control-plane-capability-grant validate-agent-wall-context
 	python3 tools/validate_agent_registry_examples.py
 
 validate-workspace-ops:
@@ -47,6 +47,13 @@ validate-control-plane-capability-grant:
 	python3 -m json.tool contracts/control-plane/control-plane-capability-grant.v0.1.schema.json >/dev/null
 	python3 -m json.tool contracts/control-plane/control-plane-capability-grant.v0.1.example.json >/dev/null
 	python3 tools/validate_control_plane_capability_grant.py
+
+validate-agent-wall-context:
+	python3 -m json.tool contracts/wallguard/agent-wall-context.v0.1.schema.json >/dev/null
+	python3 -m json.tool contracts/wallguard/agent-wall-context.active.example.json >/dev/null
+	python3 -m json.tool contracts/wallguard/agent-wall-context.revoked-invalid.json >/dev/null
+	python3 -m json.tool contracts/wallguard/agent-wall-context.contaminated-global-invalid.json >/dev/null
+	python3 tools/validate_agent_wall_context.py
 
 test:
 	python3 -m pytest -q tools/tests

--- a/contracts/wallguard/agent-wall-context.active.example.json
+++ b/contracts/wallguard/agent-wall-context.active.example.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "agent-registry.agent-wall-context.v0.1",
+  "recordType": "AgentWallContext",
+  "contextId": "agent-wall-context-agent-alpha-client-a-matter-x",
+  "agentRef": "agent-registry://agent-alpha",
+  "sessionRef": "agent-session://agent-alpha/session-wall-client-a-matter-x-001",
+  "activeWorkroomRef": "workroom://client-a/matter-x",
+  "clientRef": "client://client-a",
+  "matterRef": "matter://client-a/matter-x",
+  "wallRef": "wall://client-a/matter-x",
+  "memberships": [
+    {
+      "wallRef": "wall://client-a/matter-x",
+      "clientRef": "client://client-a",
+      "matterRef": "matter://client-a/matter-x",
+      "status": "active",
+      "scope": "full_wall_context",
+      "acknowledgmentRef": "ack://wall/client-a/matter-x/v0",
+      "effectiveFrom": "2026-05-29T00:00:00Z"
+    }
+  ],
+  "recusalState": "none",
+  "sessionState": "wall_scoped",
+  "allowedMemoryCompartments": ["client_scoped", "matter_scoped", "wall_restricted", "clean_room_derived"],
+  "allowedToolClasses": ["retrieval.read", "same-wall.collaboration", "clean-room.release.request"],
+  "receiptRefs": ["wallguard-receipt://same-wall-context-001"],
+  "evidenceRefs": ["SocioProphet/ProCybernetica#103", "SocioProphet/policy-fabric#87"],
+  "receipt_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+  "labels": {
+    "wallguard": "true",
+    "scope": "fixture"
+  }
+}

--- a/contracts/wallguard/agent-wall-context.contaminated-global-invalid.json
+++ b/contracts/wallguard/agent-wall-context.contaminated-global-invalid.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "agent-registry.agent-wall-context.v0.1",
+  "recordType": "AgentWallContext",
+  "contextId": "agent-wall-context-agent-alpha-contaminated-invalid",
+  "agentRef": "agent-registry://agent-alpha",
+  "sessionRef": "agent-session://agent-alpha/session-wall-client-a-matter-x-003",
+  "activeWorkroomRef": "workroom://client-a/matter-x",
+  "clientRef": "client://client-a",
+  "matterRef": "matter://client-a/matter-x",
+  "wallRef": "wall://client-a/matter-x",
+  "memberships": [
+    {
+      "wallRef": "wall://client-a/matter-x",
+      "clientRef": "client://client-a",
+      "matterRef": "matter://client-a/matter-x",
+      "status": "active",
+      "scope": "full_wall_context",
+      "acknowledgmentRef": "ack://wall/client-a/matter-x/v0"
+    }
+  ],
+  "recusalState": "none",
+  "sessionState": "contaminated",
+  "allowedMemoryCompartments": ["global", "firm_approved", "wall_restricted"],
+  "allowedToolClasses": ["same-wall.collaboration"],
+  "receiptRefs": ["wallguard-receipt://contaminated-context-invalid-001"],
+  "evidenceRefs": ["SocioProphet/ProCybernetica#103"],
+  "receipt_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+}

--- a/contracts/wallguard/agent-wall-context.revoked-invalid.json
+++ b/contracts/wallguard/agent-wall-context.revoked-invalid.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": "agent-registry.agent-wall-context.v0.1",
+  "recordType": "AgentWallContext",
+  "contextId": "agent-wall-context-agent-alpha-revoked-invalid",
+  "agentRef": "agent-registry://agent-alpha",
+  "sessionRef": "agent-session://agent-alpha/session-wall-client-a-matter-x-002",
+  "activeWorkroomRef": "workroom://client-a/matter-x",
+  "clientRef": "client://client-a",
+  "matterRef": "matter://client-a/matter-x",
+  "wallRef": "wall://client-a/matter-x",
+  "memberships": [
+    {
+      "wallRef": "wall://client-a/matter-x",
+      "clientRef": "client://client-a",
+      "matterRef": "matter://client-a/matter-x",
+      "status": "revoked",
+      "scope": "full_wall_context",
+      "acknowledgmentRef": "ack://wall/client-a/matter-x/v0"
+    }
+  ],
+  "recusalState": "none",
+  "sessionState": "wall_scoped",
+  "allowedMemoryCompartments": ["wall_restricted"],
+  "allowedToolClasses": ["same-wall.collaboration"],
+  "receiptRefs": ["wallguard-receipt://revoked-context-invalid-001"],
+  "evidenceRefs": ["SocioProphet/ProCybernetica#103"],
+  "receipt_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+}

--- a/contracts/wallguard/agent-wall-context.v0.1.schema.json
+++ b/contracts/wallguard/agent-wall-context.v0.1.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/agent-registry/wallguard/agent-wall-context.v0.1.schema.json",
+  "title": "Agent Wall Context v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "recordType",
+    "contextId",
+    "agentRef",
+    "sessionRef",
+    "activeWorkroomRef",
+    "clientRef",
+    "matterRef",
+    "wallRef",
+    "memberships",
+    "recusalState",
+    "sessionState",
+    "allowedMemoryCompartments",
+    "allowedToolClasses",
+    "evidenceRefs",
+    "receipt_hash"
+  ],
+  "properties": {
+    "schemaVersion": {"const": "agent-registry.agent-wall-context.v0.1"},
+    "recordType": {"const": "AgentWallContext"},
+    "contextId": {"type": "string", "minLength": 1},
+    "agentRef": {"type": "string", "minLength": 1},
+    "sessionRef": {"type": "string", "minLength": 1},
+    "activeWorkroomRef": {"type": "string", "minLength": 1},
+    "clientRef": {"type": "string", "minLength": 1},
+    "matterRef": {"type": "string", "minLength": 1},
+    "wallRef": {"type": "string", "minLength": 1},
+    "memberships": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/membership"}
+    },
+    "recusalState": {"enum": ["none", "recused", "revoked", "expired"]},
+    "sessionState": {"enum": ["clean", "wall_scoped", "contaminated", "unknown"]},
+    "allowedMemoryCompartments": {
+      "type": "array",
+      "items": {"enum": ["user_private", "client_scoped", "matter_scoped", "wall_restricted", "clean_room_derived", "firm_approved", "global"]}
+    },
+    "allowedToolClasses": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "receiptRefs": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "receipt_hash": {"type": "string", "pattern": "^sha256:"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  },
+  "$defs": {
+    "membership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wallRef", "clientRef", "matterRef", "status", "scope", "acknowledgmentRef"],
+      "properties": {
+        "wallRef": {"type": "string", "minLength": 1},
+        "clientRef": {"type": "string", "minLength": 1},
+        "matterRef": {"type": "string", "minLength": 1},
+        "status": {"enum": ["active", "revoked", "expired", "pending"]},
+        "scope": {"enum": ["read", "collaborate", "delegate", "tool_use", "memory_read", "memory_write", "full_wall_context"]},
+        "acknowledgmentRef": {"type": "string", "minLength": 1},
+        "effectiveFrom": {"type": "string"},
+        "expiresAt": {"type": "string"}
+      }
+    }
+  }
+}

--- a/tools/validate_agent_wall_context.py
+++ b/tools/validate_agent_wall_context.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Validate WallGuard agent wall-context registry contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "wallguard" / "agent-wall-context.v0.1.schema.json"
+VALID = ROOT / "contracts" / "wallguard" / "agent-wall-context.active.example.json"
+REVOKED_INVALID = ROOT / "contracts" / "wallguard" / "agent-wall-context.revoked-invalid.json"
+CONTAMINATED_INVALID = ROOT / "contracts" / "wallguard" / "agent-wall-context.contaminated-global-invalid.json"
+
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "contextId",
+    "agentRef",
+    "sessionRef",
+    "activeWorkroomRef",
+    "clientRef",
+    "matterRef",
+    "wallRef",
+    "memberships",
+    "recusalState",
+    "sessionState",
+    "allowedMemoryCompartments",
+    "allowedToolClasses",
+    "evidenceRefs",
+    "receipt_hash",
+}
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(payload, dict):
+        fail(f"{path.relative_to(ROOT)}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list) or not value:
+        fail(f"{key}: expected non-empty list")
+    return value
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    if schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail("schema must use JSON Schema draft 2020-12")
+    if schema.get("additionalProperties") is not False:
+        fail("schema must be strict")
+    missing = sorted(REQUIRED - set(schema.get("required", [])))
+    if missing:
+        fail(f"schema missing required fields: {missing}")
+
+
+def validate_context(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail(f"wall context missing required fields: {missing}")
+    if record["schemaVersion"] != "agent-registry.agent-wall-context.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "AgentWallContext":
+        fail("recordType mismatch")
+    for key in ("contextId", "agentRef", "sessionRef", "activeWorkroomRef", "clientRef", "matterRef", "wallRef"):
+        require_string(record, key)
+    if not require_string(record, "receipt_hash").startswith("sha256:"):
+        fail("receipt_hash must be sha256-bound")
+    require_list(record, "evidenceRefs")
+    memberships = require_list(record, "memberships")
+
+    active_memberships = []
+    for index, membership in enumerate(memberships):
+        if not isinstance(membership, dict):
+            fail(f"memberships[{index}] must be an object")
+        for key in ("wallRef", "clientRef", "matterRef", "status", "scope", "acknowledgmentRef"):
+            require_string(membership, key)
+        if membership["wallRef"] == record["wallRef"] and membership["clientRef"] == record["clientRef"] and membership["matterRef"] == record["matterRef"]:
+            if membership["status"] == "active":
+                active_memberships.append(membership)
+
+    if record["recusalState"] != "none":
+        fail("active wall context requires non-recused agent")
+    if not active_memberships:
+        fail("active wall context requires at least one active matching membership")
+    if record["sessionState"] in {"contaminated", "unknown"}:
+        compartments = set(record.get("allowedMemoryCompartments", []))
+        if compartments & {"global", "firm_approved"}:
+            fail("contaminated or unknown sessions must not allow global or firm-approved memory compartments")
+    if record["sessionState"] == "wall_scoped" and "wall_restricted" not in set(record.get("allowedMemoryCompartments", [])):
+        fail("wall-scoped sessions should include wall_restricted memory compartment")
+
+
+def expect_invalid(path: Path, validator: Callable[[dict[str, Any]], None], label: str) -> None:
+    try:
+        validator(load_json(path))
+    except ValidationError:
+        return
+    fail(f"invalid fixture unexpectedly validated: {label}")
+
+
+def main() -> int:
+    try:
+        validate_schema(load_json(SCHEMA))
+        validate_context(load_json(VALID))
+        expect_invalid(REVOKED_INVALID, validate_context, "revoked membership")
+        expect_invalid(CONTAMINATED_INVALID, validate_context, "contaminated global memory")
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print("OK: agent wall-context contracts validate")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first WallGuard agent wall-context registry contract.

This PR introduces:

- `contracts/wallguard/agent-wall-context.v0.1.schema.json`
- `contracts/wallguard/agent-wall-context.active.example.json`
- `contracts/wallguard/agent-wall-context.revoked-invalid.json`
- `contracts/wallguard/agent-wall-context.contaminated-global-invalid.json`
- `tools/validate_agent_wall_context.py`
- `make validate-agent-wall-context`

## Scope

Registry metadata only. This does not implement runtime enforcement, AgentPlane execution, policy evaluation, or Memory Mesh behavior.

## Semantics covered

The validator enforces:

- active wall context requires an active matching membership
- active wall context requires non-recused agent state
- contaminated or unknown sessions cannot allow `global` or `firm_approved` memory compartments
- wall-scoped sessions include `wall_restricted` memory scope
- receipt hashes must be SHA-256-bound

## Links

- Parent spine: SocioProphet/sociosphere#392
- Policy issue: SocioProphet/agent-registry#44
- Doctrine: SocioProphet/ProCybernetica#103
- Related schema tranche: SocioProphet/policy-fabric#87

## Validation

Not yet run in CI at PR creation. Manual diff review confirms six files changed:

- one schema
- one valid fixture
- two invalid fixtures
- one validator
- Makefile target wiring

Expected validation command:

```bash
make validate-agent-wall-context
```

## Known gaps

`policy-fabric#87` is still parked because `Repo Health` fails at its Doctor step and the connector is not exposing the diagnostic Doctor output. This PR is independent registry metadata and does not depend on merging that PR first.